### PR TITLE
[K8s] Enable k3s containerd import for executors

### DIFF
--- a/python/cornserve/services/task_manager/manager.py
+++ b/python/cornserve/services/task_manager/manager.py
@@ -311,7 +311,7 @@ class TaskManager:
                     kclient.V1Container(
                         name="task-executor",
                         image=self.launch_info.get_container_image(),
-                        image_pull_policy="Always",
+                        image_pull_policy="IfNotPresent",
                         args=self.launch_info.get_container_args(gpus, port),
                         ports=[kclient.V1ContainerPort(container_port=port, name="http")],
                         resources=kclient.V1ResourceRequirements(


### PR DESCRIPTION
Docker images of task executors are particularly large, and we get hit by the size twice: first when we push it to the private image registry, and then again when the image is pulled into k3s containerd when the pod is spawned.

There's a way to only get hit once by directly exporting a built Docker image to k3s containerd.

```console
$ REGISTRY=local bash scripts/build-and-push-images.sh vllm
```

This will build the image and export it directly to k3s containerd's image directory. The image pull policy of task executors are how `IfNotPresent`; thus when changes are made to executors, you can build and export the image directly to k3s containerd and k3s will use the updated image instead of trying to pull it fresh from the private registry.
