### PR TITLE
[CI] Add Pyupgrade to Ruff

### DIFF
--- a/python/cornserve/app/base.py
+++ b/python/cornserve/app/base.py
@@ -1,5 +1,7 @@
 """Base classes for cornserve applications."""
 
+from __future__ import annotations
+
 from typing import ClassVar
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/python/cornserve/cli.py
+++ b/python/cornserve/cli.py
@@ -44,7 +44,7 @@ class Alias:
         # Alias -> App ID
         self.aliases = {}
         if file_path.exists():
-            with open(file_path, "r") as file:
+            with open(file_path) as file:
                 self.aliases = json.load(file)
 
     def get(self, alias: str) -> str | None:

--- a/python/cornserve/logging.py
+++ b/python/cornserve/logging.py
@@ -1,9 +1,12 @@
 """Logging utilities for the Cornserve project."""
 
+from __future__ import annotations
+
 import logging
 import os
 import sys
-from typing import Any, MutableMapping
+from collections.abc import MutableMapping
+from typing import Any
 
 
 def get_logger(

--- a/python/cornserve/services/gateway/app/manager.py
+++ b/python/cornserve/services/gateway/app/manager.py
@@ -1,5 +1,7 @@
 """The App Manager registers, invokes, and unregisters applications."""
 
+from __future__ import annotations
+
 import asyncio
 import importlib.util
 import uuid

--- a/python/cornserve/services/gateway/app/models.py
+++ b/python/cornserve/services/gateway/app/models.py
@@ -1,9 +1,11 @@
 """Type definitions for the App Manager."""
 
+from __future__ import annotations
+
 import enum
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Callable, Coroutine, Type
 
 from cornserve.app.base import AppConfig, AppRequest, AppResponse
 
@@ -26,9 +28,9 @@ class AppClasses:
         serve_fn: The function that implements the app's logic.
     """
 
-    request_cls: Type[AppRequest]
-    response_cls: Type[AppResponse]
-    config_cls: Type[AppConfig]
+    request_cls: type[AppRequest]
+    response_cls: type[AppResponse]
+    config_cls: type[AppConfig]
     serve_fn: Callable[[AppRequest], Coroutine[None, None, AppResponse]]
 
 

--- a/python/cornserve/services/gateway/entrypoint.py
+++ b/python/cornserve/services/gateway/entrypoint.py
@@ -1,5 +1,7 @@
 """Spins up the Gateway service."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 import signal

--- a/python/cornserve/services/resource_manager/grpc.py
+++ b/python/cornserve/services/resource_manager/grpc.py
@@ -1,5 +1,7 @@
 """Resource Manager gRPC server."""
 
+from __future__ import annotations
+
 import grpc
 
 from cornserve.logging import get_logger

--- a/python/cornserve/services/sidecar/api.py
+++ b/python/cornserve/services/sidecar/api.py
@@ -15,7 +15,7 @@ import weakref
 from concurrent.futures import ThreadPoolExecutor
 from functools import reduce
 from operator import mul
-from typing import List, Optional, cast
+from typing import cast
 
 import grpc
 import torch
@@ -161,7 +161,7 @@ class TensorSidecarAsyncReceiver(TensorSidecarReceiverBase):
         sidecar_rank: int,
         shape: tuple[int, ...],
         dtype: torch.dtype,
-        peers: Optional[list[int]] = None,
+        peers: list[int] | None = None,
     ) -> None:
         """Constructor for the sidecar receiver.
 
@@ -444,7 +444,7 @@ class TensorSidecarSender(TensorSidecarSenderBase):
         self,
         chunk: torch.Tensor,
         id: str,
-        dst_sidecar_ranks: List[int],
+        dst_sidecar_ranks: list[int],
         chunk_id: int = 0,
         num_chunks: int = 1,
     ) -> None:
@@ -515,7 +515,7 @@ class TensorSidecarSender(TensorSidecarSenderBase):
         shard: torch.Tensor,
         chunk_size: int,
         shard_offset: int,
-        dst_sidecar_ranks: List[int],
+        dst_sidecar_ranks: list[int],
         chunk_id: int,
         num_chunks: int,
     ) -> None:

--- a/python/cornserve/services/task_dispatcher/dispatcher.py
+++ b/python/cornserve/services/task_dispatcher/dispatcher.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections import defaultdict
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Iterator
+from typing import Any
 
 import grpc
 import httpx
@@ -68,7 +69,7 @@ def iter_data_forwards(obj: object) -> Iterator[DataForward]:
     """
     if isinstance(obj, DataForward):
         yield obj
-    elif isinstance(obj, (list, tuple)):
+    elif isinstance(obj, list | tuple):
         for item in obj:
             yield from iter_data_forwards(item)
     elif isinstance(obj, dict):

--- a/python/cornserve/task/base.py
+++ b/python/cornserve/task/base.py
@@ -8,9 +8,10 @@ import os
 import uuid
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, ClassVar, Generator, Generic, Iterable, Self, TypeVar, final
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Self, TypeVar, final
 
 import httpx
 from opentelemetry import trace

--- a/python/cornserve/task/forward.py
+++ b/python/cornserve/task/forward.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import enum
 import uuid
-from typing import Generic, TypeVar
+from typing import Generic, Self, TypeVar
 
 from pydantic import BaseModel, Field, model_validator
-from typing_extensions import Self
 
 
 class Tensor:

--- a/python/cornserve/task_executors/eric/config.py
+++ b/python/cornserve/task_executors/eric/config.py
@@ -5,10 +5,13 @@ Config values will be supplied by the Task Manager when Eric is launched.
 Config values should be kept in sync with `cornserve.task_executors.launch`.
 """
 
+from __future__ import annotations
+
+from typing import Self
+
 from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt, model_validator
 from transformers.configuration_utils import PretrainedConfig
 from transformers.models.auto.configuration_auto import AutoConfig
-from typing_extensions import Self
 
 
 class ModelConfig(BaseModel):

--- a/python/cornserve/task_executors/eric/distributed/parallel.py
+++ b/python/cornserve/task_executors/eric/distributed/parallel.py
@@ -1,5 +1,7 @@
 """PyTorch Distributed management and collectives for tensor parallelism."""
 
+from __future__ import annotations
+
 import torch
 
 from cornserve.logging import get_logger

--- a/python/cornserve/task_executors/eric/engine/client.py
+++ b/python/cornserve/task_executors/eric/engine/client.py
@@ -1,5 +1,7 @@
 """The engine client lives in the router process and interacts with the engine process."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 from asyncio.futures import Future

--- a/python/cornserve/task_executors/eric/engine/core.py
+++ b/python/cornserve/task_executors/eric/engine/core.py
@@ -1,5 +1,7 @@
 """Eric engine core."""
 
+from __future__ import annotations
+
 import multiprocessing as mp
 import queue
 import signal

--- a/python/cornserve/task_executors/eric/engine/scheduler.py
+++ b/python/cornserve/task_executors/eric/engine/scheduler.py
@@ -1,7 +1,7 @@
 """The scheduler is responsible for batching embedding requests."""
 
 from collections import defaultdict
-from typing import Generator
+from collections.abc import Generator
 
 from opentelemetry import propagate, trace
 

--- a/python/cornserve/task_executors/eric/entrypoint.py
+++ b/python/cornserve/task_executors/eric/entrypoint.py
@@ -1,5 +1,7 @@
 """Spins up Eric."""
 
+from __future__ import annotations
+
 import asyncio
 import signal
 

--- a/python/cornserve/task_executors/eric/executor/executor.py
+++ b/python/cornserve/task_executors/eric/executor/executor.py
@@ -1,5 +1,7 @@
 """The model executor manages multiple workers that execute inference."""
 
+from __future__ import annotations
+
 import os
 import signal
 import time

--- a/python/cornserve/task_executors/eric/executor/loader.py
+++ b/python/cornserve/task_executors/eric/executor/loader.py
@@ -1,5 +1,7 @@
 """Instantiating the PyTorch model and loading Hugging Face Hub model weights."""
 
+from __future__ import annotations
+
 import contextlib
 import fnmatch
 import hashlib
@@ -7,7 +9,7 @@ import importlib
 import json
 import os
 import tempfile
-from typing import Literal, Type
+from typing import Literal
 
 import filelock
 import huggingface_hub.errors
@@ -74,7 +76,7 @@ def load_model(
 
     # Import the model class
     try:
-        model_class: Type[EricModel] = getattr(
+        model_class: type[EricModel] = getattr(
             importlib.import_module(f"cornserve.task_executors.eric.models.{registry_entry.module}"),
             registry_entry.class_name,
         )

--- a/python/cornserve/task_executors/eric/executor/worker.py
+++ b/python/cornserve/task_executors/eric/executor/worker.py
@@ -1,5 +1,7 @@
 """Worker processes use the GPUs to run tensor parallel inference."""
 
+from __future__ import annotations
+
 import multiprocessing as mp
 import pickle
 import signal

--- a/python/cornserve/task_executors/eric/models/base.py
+++ b/python/cornserve/task_executors/eric/models/base.py
@@ -1,5 +1,7 @@
 """Base class for all models in Eric."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Callable
 

--- a/python/cornserve/task_executors/eric/models/layers/activations.py
+++ b/python/cornserve/task_executors/eric/models/layers/activations.py
@@ -1,5 +1,7 @@
 """Activation functions."""
 
+from __future__ import annotations
+
 import torch
 import torch.nn as nn
 

--- a/python/cornserve/task_executors/eric/models/layers/attention.py
+++ b/python/cornserve/task_executors/eric/models/layers/attention.py
@@ -1,5 +1,7 @@
 """Generic attention implementation for ViTs."""
 
+from __future__ import annotations
+
 import torch
 import torch.nn as nn
 from xformers.ops import memory_efficient_attention_forward  # type: ignore

--- a/python/cornserve/task_executors/eric/models/layers/linear.py
+++ b/python/cornserve/task_executors/eric/models/layers/linear.py
@@ -1,3 +1,7 @@
+"""Linear layers with tensor parallelism."""
+
+from __future__ import annotations
+
 from typing import Any, Literal
 
 import torch

--- a/python/cornserve/task_executors/eric/models/layers/siglip.py
+++ b/python/cornserve/task_executors/eric/models/layers/siglip.py
@@ -1,3 +1,7 @@
+"""SigLIP vision encoder."""
+
+from __future__ import annotations
+
 import math
 
 import torch

--- a/python/cornserve/task_executors/eric/models/layers/vit.py
+++ b/python/cornserve/task_executors/eric/models/layers/vit.py
@@ -1,3 +1,7 @@
+"""Vision Transformer."""
+
+from __future__ import annotations
+
 import torch.nn as nn
 from transformers.models.siglip import SiglipVisionConfig
 

--- a/python/cornserve/task_executors/eric/models/registry.py
+++ b/python/cornserve/task_executors/eric/models/registry.py
@@ -1,5 +1,7 @@
 """The registry holds model-specific information."""
 
+from __future__ import annotations
+
 import enum
 from dataclasses import dataclass, field
 

--- a/python/cornserve/task_executors/eric/router/processor.py
+++ b/python/cornserve/task_executors/eric/router/processor.py
@@ -1,5 +1,7 @@
 """Defines the Processor class for handling modality preprocessing."""
 
+from __future__ import annotations
+
 import asyncio
 import base64
 import importlib

--- a/python/cornserve/task_executors/eric/schema.py
+++ b/python/cornserve/task_executors/eric/schema.py
@@ -74,7 +74,7 @@ class EngineEnqueueRequest:
     span: Span | None = None
 
     @classmethod
-    def from_msgpack(cls, msg: EngineEnqueueMessage) -> "EngineEnqueueRequest":
+    def from_msgpack(cls, msg: EngineEnqueueMessage) -> EngineEnqueueRequest:
         """Create an engine enqueue request from a engine enqueue message."""
         req = cls(request_id=msg.request_id, data=msg.data)
         if msg.otel_carrier:

--- a/python/cornserve/task_executors/eric/utils/distributed.py
+++ b/python/cornserve/task_executors/eric/utils/distributed.py
@@ -1,6 +1,8 @@
 """Utilities for distributed inference."""
 
-from typing import Sequence
+from __future__ import annotations
+
+from collections.abc import Sequence
 
 import torch
 

--- a/python/cornserve/task_executors/eric/utils/network.py
+++ b/python/cornserve/task_executors/eric/utils/network.py
@@ -1,5 +1,7 @@
 """Utilities for networking."""
 
+from __future__ import annotations
+
 import socket
 
 

--- a/python/cornserve/task_executors/eric/utils/process.py
+++ b/python/cornserve/task_executors/eric/utils/process.py
@@ -1,5 +1,7 @@
 """Utilities for process management."""
 
+from __future__ import annotations
+
 import contextlib
 import os
 import signal

--- a/python/cornserve/task_executors/eric/utils/serde.py
+++ b/python/cornserve/task_executors/eric/utils/serde.py
@@ -1,7 +1,9 @@
 """Utilities for serializing and deserializing objects."""
 
+from __future__ import annotations
+
 import pickle
-from typing import Any, Type
+from typing import Any
 
 import numpy as np
 import torch
@@ -31,7 +33,7 @@ class MsgpackEncoder:
 class MsgpackDecoder:
     """Msgpack decoder that implements custom deserialization."""
 
-    def __init__(self, ty: Type | None = None) -> None:
+    def __init__(self, ty: type | None = None) -> None:
         """Initialize the decoder."""
         self.decoder = msgpack.Decoder(type=ty, ext_hook=ext_hook)
 

--- a/python/cornserve/task_executors/eric/utils/zmq.py
+++ b/python/cornserve/task_executors/eric/utils/zmq.py
@@ -1,8 +1,11 @@
 """Utilities for creating and managing ZMQ sockets."""
 
+from __future__ import annotations
+
 import contextlib
 import tempfile
-from typing import Iterator, overload
+from collections.abc import Iterator
+from typing import overload
 from uuid import uuid4
 
 import zmq

--- a/python/cornserve/tracing.py
+++ b/python/cornserve/tracing.py
@@ -1,5 +1,7 @@
 """OpenTelemetry configuration for the cornserve services."""
 
+from __future__ import annotations
+
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -96,7 +96,7 @@ select = [
   "D",   # pydocstyle
   "PL",  # pylint
   "N",   # pep8-naming
-  # "UP",  # pyupgrade
+  "UP",  # pyupgrade
   "B",   # flake8-bugbear (detects likely bugs)
   "G",   # flake8-logging-format (complains about logging)
   "SIM", # flake8-simplify (suggests code simplifications)


### PR DESCRIPTION
Pyupgrade points out Python features that are now superseded by newer features, like the use of `typing.Optional`, `typing.List`, etc. I've added pyupgrade via Ruff and fixed all new lint errors.