### PR TITLE
[Eric] Qwen 2.5 VL and output correctness tests

### DIFF
--- a/python/cornserve/task_executors/eric/models/layers/norm.py
+++ b/python/cornserve/task_executors/eric/models/layers/norm.py
@@ -4,6 +4,9 @@ import torch
 import torch.nn as nn
 
 
+# TODO: Get RMSNorm from vLLM
+
+
 class GemmaRMSNorm(nn.Module):
     """RMS normalization for Gemma.
 

--- a/python/cornserve/task_executors/eric/models/layers/norm.py
+++ b/python/cornserve/task_executors/eric/models/layers/norm.py
@@ -4,7 +4,70 @@ import torch
 import torch.nn as nn
 
 
-# TODO: Get RMSNorm from vLLM
+class RMSNorm(nn.Module):
+    """Root mean square normalization.
+
+    Computes x -> w * x / sqrt(E[x^2] + eps) where w is the learned weight.
+    Refer to https://arxiv.org/abs/1910.07467
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        var_hidden_size: int | None = None,
+        has_weight: bool = True,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+
+        self.hidden_size = hidden_size
+        self.variance_epsilon = eps
+        self.variance_size_override = None if var_hidden_size == hidden_size else var_hidden_size
+        self.has_weight = has_weight
+        if dtype is not None:
+            self.weight = torch.ones(hidden_size, dtype=dtype)
+        else:
+            self.weight = torch.ones(hidden_size)
+        if self.has_weight:
+            self.weight = nn.Parameter(self.weight)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        """PyTorch-native implementation equivalent to forward()."""
+        orig_dtype = x.dtype
+        x = x.to(torch.float32)
+        if residual is not None:
+            x = x + residual.to(torch.float32)
+            residual = x.to(orig_dtype)
+
+        hidden_size = x.shape[-1]
+        if hidden_size != self.hidden_size:
+            raise ValueError(f"Expected hidden_size to be {self.hidden_size}, but found: {hidden_size}")
+
+        if self.variance_size_override is None:
+            x_var = x
+        else:
+            if hidden_size < self.variance_size_override:
+                raise ValueError(
+                    f"Expected hidden_size to be at least {self.variance_size_override}, but found: {hidden_size}"
+                )
+
+            x_var = x[:, :, : self.variance_size_override]
+
+        variance = x_var.pow(2).mean(dim=-1, keepdim=True)
+
+        x = x * torch.rsqrt(variance + self.variance_epsilon)
+        x = x.to(orig_dtype)
+        if self.has_weight:
+            x = x * self.weight
+        if residual is None:
+            return x
+        else:
+            return x, residual
 
 
 class GemmaRMSNorm(nn.Module):

--- a/python/cornserve/task_executors/eric/models/llava_onevision.py
+++ b/python/cornserve/task_executors/eric/models/llava_onevision.py
@@ -299,9 +299,9 @@ class ModalityProcessor(BaseModalityProcessor):
 
         def processor(image: npt.NDArray) -> dict[str, npt.NDArray]:
             """Invoke the HF processor and convert to dict."""
-            out = self.image_processor.preprocess(images=[image], return_tensors="np")
+            out = self.image_processor.preprocess(images=[image], return_tensors="pt")
             # Batch size is going to be 1, so squeeze it out
-            return {k: v.squeeze(0) for k, v in out.data.items()}
+            return {k: v.numpy().squeeze(0) for k, v in out.data.items()}
 
         return processor
 
@@ -310,8 +310,8 @@ class ModalityProcessor(BaseModalityProcessor):
 
         def processor(video: npt.NDArray) -> dict[str, npt.NDArray]:
             """Invoke the HF processor and convert to dict."""
-            out = self.video_processor.preprocess(videos=[video], return_tensors="np")
+            out = self.video_processor.preprocess(videos=[video], return_tensors="pt")
             # Batch size is going to be 1, so squeeze it out
-            return {k: v.squeeze(0) for k, v in out.data.items()}
+            return {k: v.numpy().squeeze(0) for k, v in out.data.items()}
 
         return processor

--- a/python/cornserve/task_executors/eric/models/qwen2_5_vl.py
+++ b/python/cornserve/task_executors/eric/models/qwen2_5_vl.py
@@ -1,0 +1,215 @@
+"""Qwen2.5-VL Vision Transformer."""
+
+from functools import partial
+
+import torch
+import torch.nn as nn
+from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import Qwen2_5_VLConfig
+
+from .base import EricModel
+
+
+class Qwen2_5_VisionTransformer(EricModel):
+    def __init__(self, config: Qwen2_5_VLConfig) -> None:
+        super().__init__()
+        vision_config = config.vision_config
+        patch_size = vision_config.patch_size
+        temporal_patch_size = vision_config.temporal_patch_size
+        in_channels = vision_config.in_channels
+        depth = vision_config.depth
+
+        self.hidden_size = vision_config.hidden_size
+        self.num_heads = vision_config.num_heads
+
+        # args for get_window_index
+        self.window_size = vision_config.window_size
+        self.patch_size = vision_config.patch_size
+        self.spatial_merge_size = vision_config.spatial_merge_size
+        self.fullatt_block_indexes = vision_config.fullatt_block_indexes
+        self.spatial_merge_unit = self.spatial_merge_size**2
+
+        self.patch_embed = Qwen2_5_VisionPatchEmbed(
+            patch_size=patch_size,
+            temporal_patch_size=temporal_patch_size,
+            in_channels=in_channels,
+            hidden_size=self.hidden_size,
+        )
+
+        norm_eps = getattr(config, "rms_norm_eps", 1e-6),
+        norm_layer = partial(RMSNorm, eps=norm_eps)
+        head_dim = self.hidden_size // self.num_heads
+        self.rotary_pos_emb = Qwen2_5_VisionRotaryEmbedding(head_dim // 2)
+
+        self.blocks = nn.ModuleList([
+            Qwen2_5_VisionBlock(
+                dim=self.hidden_size,
+                num_heads=self.num_heads,
+                mlp_hidden_dim=vision_config.intermediate_size,
+                act_fn=_ACTIVATION_REGISTRY[vision_config.hidden_act],
+                norm_layer=norm_layer,
+            )
+            for layer_idx in range(depth)
+        ])
+        self.merger = Qwen2_5_VisionPatchMerger(
+            d_model=vision_config.out_hidden_size,
+            context_dim=self.hidden_size,
+            norm_layer=norm_layer,
+            spatial_merge_size=self.spatial_merge_size,
+        )
+        self.attn_backend: _Backend = get_vit_attn_backend(support_fa=True)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.patch_embed.proj.weight.device
+
+    @property
+    def chunk_shape(self) -> tuple[int, ...]:
+        return (1, self.hidden_size)
+
+    def rot_pos_emb(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        pos_ids = []
+        for t, h, w in grid_thw:
+            hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
+            wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
+            hpos_ids = hpos_ids.reshape(
+                h // self.spatial_merge_size,
+                self.spatial_merge_size,
+                w // self.spatial_merge_size,
+                self.spatial_merge_size,
+            ).permute(0, 2, 1, 3).flatten()
+            wpos_ids = wpos_ids.reshape(
+                h // self.spatial_merge_size,
+                self.spatial_merge_size,
+                w // self.spatial_merge_size,
+                self.spatial_merge_size,
+            ).permute(0, 2, 1, 3).flatten()
+            pos_ids.append(
+                torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
+        pos_ids = torch.cat(pos_ids, dim=0)
+        max_grid_size = grid_thw[:, 1:].max()
+        rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)
+        rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
+        return rotary_pos_emb
+
+    def get_window_index(self, grid_thw):
+        window_index: list = []
+        cu_window_seqlens: list = [0]
+        window_index_id = 0
+        vit_merger_window_size = (self.window_size //
+                                  self.spatial_merge_size // self.patch_size)
+
+        for grid_t, grid_h, grid_w in grid_thw:
+            llm_grid_h = grid_h // self.spatial_merge_size
+            llm_grid_w = grid_w // self.spatial_merge_size
+            index = torch.arange(grid_t * llm_grid_h * llm_grid_w).reshape(
+                grid_t, llm_grid_h, llm_grid_w)
+            pad_h = vit_merger_window_size - llm_grid_h % vit_merger_window_size
+            pad_w = vit_merger_window_size - llm_grid_w % vit_merger_window_size
+            num_windows_h = (llm_grid_h + pad_h) // vit_merger_window_size
+            num_windows_w = (llm_grid_w + pad_w) // vit_merger_window_size
+            index_padded = F.pad(index, (0, pad_w, 0, pad_h), 'constant', -100)
+            index_padded = index_padded.reshape(grid_t, num_windows_h,
+                                                vit_merger_window_size,
+                                                num_windows_w,
+                                                vit_merger_window_size)
+            index_padded = index_padded.permute(0, 1, 3, 2, 4).reshape(
+                grid_t, num_windows_h * num_windows_w, vit_merger_window_size,
+                vit_merger_window_size)
+            seqlens = (index_padded != -100).sum([2, 3]).reshape(-1)
+            index_padded = index_padded.reshape(-1)
+            index_new = index_padded[index_padded != -100]
+            window_index.append(index_new + window_index_id)
+            cu_seqlens_tmp = seqlens.cumsum(
+                0) * self.spatial_merge_unit + cu_window_seqlens[-1]
+            cu_window_seqlens.extend(cu_seqlens_tmp.tolist())
+            window_index_id += (grid_t * llm_grid_h * llm_grid_w).item()
+        window_index = torch.cat(window_index, dim=0)
+        return window_index, cu_window_seqlens
+
+    def compute_attn_mask_seqlen(
+        self,
+        cu_seqlens: torch.Tensor,
+    ) -> tuple[Optional[int], Optional[list[int]]]:
+        max_seqlen, seqlens = None, None
+        if self.attn_backend == _Backend.FLASH_ATTN:
+            max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
+        elif self.attn_backend == _Backend.XFORMERS:
+            seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        return max_seqlen, seqlens
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
+        # patchify
+        hidden_states = x.to(device=self.device, dtype=self.dtype)
+        hidden_states = self.patch_embed(hidden_states)
+
+        # compute position embedding
+        rotary_pos_emb = self.rot_pos_emb(grid_thw)
+
+        # windows attention
+        window_index, cu_window_seqlens = self.get_window_index(grid_thw)
+        cu_window_seqlens = torch.tensor(
+            cu_window_seqlens,
+            device=hidden_states.device,
+            dtype=grid_thw.dtype if torch.jit.is_tracing() else torch.int32)
+        cu_window_seqlens = torch.unique_consecutive(cu_window_seqlens)
+        seq_len, _ = hidden_states.size()
+        hidden_states = hidden_states.reshape(
+            seq_len // self.spatial_merge_unit, self.spatial_merge_unit, -1)
+        hidden_states = hidden_states[window_index, :, :]
+        hidden_states = hidden_states.reshape(seq_len, -1)
+        rotary_pos_emb = rotary_pos_emb.reshape(
+            seq_len // self.spatial_merge_unit, self.spatial_merge_unit, -1)
+        rotary_pos_emb = rotary_pos_emb[window_index, :, :]
+        rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1)
+        # compute cu_seqlens
+        cu_seqlens = torch.repeat_interleave(grid_thw[:, 1] * grid_thw[:, 2],
+                                             grid_thw[:, 0]).cumsum(
+                                                 dim=0, dtype=torch.int32)
+        cu_seqlens = F.pad(cu_seqlens, (1, 0), "constant", 0)
+
+        # transformers
+        hidden_states = hidden_states.unsqueeze(1)
+
+        # pre-compute seqlens for window/full attn to reduce cuMemcpy operations
+        max_seqlen_full, seqlens_full = self.compute_attn_mask_seqlen(
+            cu_seqlens)
+        max_seqlen_window, seqlens_window = self.compute_attn_mask_seqlen(
+            cu_window_seqlens)
+        for layer_num, blk in enumerate(self.blocks):
+            if layer_num in self.fullatt_block_indexes:
+                cu_seqlens_now = cu_seqlens
+                max_seqlen_now = max_seqlen_full
+                seqlens_now = seqlens_full
+            else:
+                cu_seqlens_now = cu_window_seqlens
+                max_seqlen_now = max_seqlen_window
+                seqlens_now = seqlens_window
+
+            hidden_states = blk(
+                hidden_states,
+                cu_seqlens=cu_seqlens_now,
+                rotary_pos_emb=rotary_pos_emb,
+                max_seqlen=max_seqlen_now,
+                seqlens=seqlens_now,
+            )
+
+        # For Qwen2.5-VL-3B, float16 will overflow at last block
+        # for long visual tokens sequences.
+        if hidden_states.dtype == torch.float16:
+            hidden_states = cast_overflow_tensors(hidden_states)
+
+        # adapter
+        hidden_states = self.merger(hidden_states)
+        reverse_indices = torch.argsort(window_index)
+        hidden_states = hidden_states[reverse_indices, :]
+        return hidden_states
+
+

--- a/python/cornserve/task_executors/eric/models/qwen2_5_vl.py
+++ b/python/cornserve/task_executors/eric/models/qwen2_5_vl.py
@@ -1,12 +1,282 @@
 """Qwen2.5-VL Vision Transformer."""
 
 from functools import partial
+from collections.abc import Callable
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+import numpy.typing as npt
+from einops import rearrange
+from transformers.models.auto.image_processing_auto import AutoImageProcessor
 from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import Qwen2_5_VLConfig
+from flash_attn import flash_attn_varlen_func
+from flash_attn.layers.rotary import apply_rotary_emb
 
 from .base import EricModel
+from .layers.norm import RMSNorm
+from .layers.activations import get_act_fn
+from .layers.linear import ColumnParallelLinear, RowParallelLinear, QKVParallelLinear
+from cornserve.task_executors.eric.api import Modality
+from cornserve.task_executors.eric.distributed import parallel
+from cornserve.task_executors.eric.router.processor import BaseModalityProcessor
+from cornserve.task_executors.eric.utils import distributed as dist_utils
+
+
+def apply_rotary_pos_emb_vision(t: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
+    t_ = t.float()
+    cos = freqs.cos()
+    sin = freqs.sin()
+
+    output = apply_rotary_emb(t_, cos, sin).type_as(t)
+
+    return output
+
+
+def all_gather_interleave(local_tensor, hidden_size: int, tp_size: int):
+    """All-gather the input tensor interleavely across model parallel group."""
+    import torch.distributed as dist
+
+    gathered_tensors = [torch.zeros_like(local_tensor) for _ in range(tp_size)]
+    dist.all_gather(gathered_tensors, local_tensor, group=parallel.get_tensor_parallel_group().process_group)
+
+    gathered_tensors_split = [torch.split(tensor, hidden_size // tp_size, -1) for tensor in gathered_tensors]
+    ordered_tensors = [tensor for pair in zip(*gathered_tensors_split) for tensor in pair]
+    result_tensor = torch.cat(ordered_tensors, dim=-1)
+    return result_tensor
+
+
+def cast_overflow_tensors(
+    tensors: torch.Tensor,
+    offset: float = 1000,
+) -> torch.Tensor:
+    if tensors.isinf().any() or tensors.isnan().any():
+        clamp_value = torch.finfo(tensors.dtype).max - offset
+        tensors = torch.clamp(tensors, min=-clamp_value, max=clamp_value)
+    return tensors
+
+
+class Qwen2_5_VisionAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        projection_size: int,
+    ) -> None:
+        super().__init__()
+        # Per attention head and per partition values.
+        self.tp_group = parallel.get_tensor_parallel_group()
+        self.tp_size = self.tp_group.world_size
+        self.tp_rank = self.tp_group.rank
+        self.hidden_size_per_attention_head = dist_utils.divide(projection_size, num_heads)
+        self.num_attention_heads_per_partition = dist_utils.divide(num_heads, self.tp_size)
+        self.embed_dim = embed_dim
+
+        self.qkv = ColumnParallelLinear(input_size=embed_dim, output_size=3 * projection_size)
+        # self.qkv = QKVParallelLinear(
+        #     hidden_size=embed_dim,
+        #     head_size=self.hidden_size_per_attention_head,
+        #     total_num_heads=num_heads,
+        #     total_num_kv_heads=num_heads,
+        #     bias=True)
+        self.proj = RowParallelLinear(input_size=projection_size, output_size=embed_dim)
+
+    def split_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        # [s, b, 3 * head * head_dim]
+        seq_len, bs, _ = qkv.shape
+        if self.tp_size > 1:
+            # qkv = all_gather_interleave(qkv, self.embed_dim, self.tp_size)
+            qkv = self.tp_group.all_gather(qkv)
+
+        # [s, b, 3 * head * head_dim] -> 3 * [s, b, head * head_dim]
+        q, k, v = qkv.chunk(3, dim=2)
+
+        # 3 * [s, b, head * head_dim]
+        if self.tp_size > 1:
+            splitter = partial(dist_utils.split_tensor_along_last_dim, num_partitions=self.tp_size)
+            q = splitter(q)[self.tp_rank]
+            k = splitter(k)[self.tp_rank]
+            v = splitter(v)[self.tp_rank]
+
+        # 3 * [s, b, head * head_dim] -> 3 * [s, b, head, head_dim]
+        new_shape = (seq_len, bs, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
+        q, k, v = (x.view(*new_shape) for x in (q, k, v))
+        return q, k, v
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb: torch.Tensor,
+        max_seqlen: int | None = None,  # Only used for Flash Attention
+    ) -> torch.Tensor:
+        # [s, b, c] --> [s, b, head * 3 * head_dim]
+        x, _ = self.qkv(x)
+
+        # [s, b, 3 * head * head_dim] -> 3 * [s, b, head, head_dim]
+        q, k, v = self.split_qkv(x)
+        batch_size = q.shape[1]
+
+        q, k, v = (rearrange(x, "s b ... -> b s ...").contiguous() for x in (q, k, v))
+        if rotary_pos_emb is not None:
+            q = apply_rotary_pos_emb_vision(q, rotary_pos_emb)
+            k = apply_rotary_pos_emb_vision(k, rotary_pos_emb)
+
+        # from vllm_flash_attn.flash_attn_interface import (
+        #   flash_attn_varlen_func)
+
+        q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
+
+        output = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_k=max_seqlen,
+            dropout_p=0,
+            causal=False,
+        )
+
+        context_layer = rearrange(output, "(b s) ... -> b s ...", b=batch_size)
+        context_layer = rearrange(context_layer, "b s h d -> s b (h d)").contiguous()
+
+        output, _ = self.proj(context_layer)
+        return output
+
+
+class Qwen2_5_VisionMLP(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int,
+        bias: bool = False,
+        act_fn: Callable[[torch.Tensor], torch.Tensor] = F.silu,
+    ) -> None:
+        super().__init__()
+        self.gate_proj = ColumnParallelLinear(in_features, hidden_features, bias=bias)
+        self.up_proj = ColumnParallelLinear(in_features, hidden_features, bias=bias)
+        self.down_proj = RowParallelLinear(hidden_features, in_features, bias=bias)
+        self.act_fn = act_fn
+
+    def forward(self, x: torch.Tensor):
+        x_gate, _ = self.gate_proj(x)
+        x_gate = self.act_fn(x_gate)
+        x_up, _ = self.up_proj(x)
+        x_down, _ = self.down_proj(x_gate * x_up)
+        return x_down
+
+
+class Qwen2_5_VisionBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_hidden_dim: int,
+        act_fn: Callable[[torch.Tensor], torch.Tensor] = F.silu,
+        norm_layer: Callable[[int], nn.Module] | None = None,
+    ) -> None:
+        super().__init__()
+        if norm_layer is None:
+            norm_layer = partial(nn.LayerNorm, eps=1e-6)
+        self.norm1 = norm_layer(dim)
+        self.norm2 = norm_layer(dim)
+        self.attn = Qwen2_5_VisionAttention(embed_dim=dim, num_heads=num_heads, projection_size=dim)
+        self.mlp = Qwen2_5_VisionMLP(dim, mlp_hidden_dim, act_fn=act_fn, bias=True)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb: torch.Tensor,
+        max_seqlen: int | None = None,
+    ) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), cu_seqlens=cu_seqlens, rotary_pos_emb=rotary_pos_emb, max_seqlen=max_seqlen)
+
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class Qwen2_5_VisionPatchEmbed(nn.Module):
+    def __init__(
+        self,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        in_channels: int = 3,
+        hidden_size: int = 1152,
+    ) -> None:
+        super().__init__()
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.hidden_size = hidden_size
+
+        kernel_size = (temporal_patch_size, patch_size, patch_size)
+        self.proj = nn.Conv3d(in_channels, hidden_size, kernel_size=kernel_size, stride=kernel_size, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        L, C = x.shape
+        x = x.view(L, -1, self.temporal_patch_size, self.patch_size, self.patch_size)
+        x = self.proj(x).view(L, self.hidden_size)
+        return x
+
+
+class Qwen2_5_VisionPatchMerger(nn.Module):
+    def __init__(
+        self,
+        d_model: int,
+        context_dim: int,
+        norm_layer: Callable[[int], nn.Module] | None = None,
+        spatial_merge_size: int = 2,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = context_dim * (spatial_merge_size**2)
+        if norm_layer is None:
+            norm_layer = partial(nn.LayerNorm, eps=1e-6)
+        self.ln_q = norm_layer(context_dim)
+        self.mlp = nn.ModuleList(
+            [
+                ColumnParallelLinear(self.hidden_size, self.hidden_size, bias=True),
+                nn.GELU(),
+                RowParallelLinear(self.hidden_size, d_model, bias=True),
+            ]
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.ln_q(x)
+        x = x.view(-1, self.hidden_size)
+
+        mlp_fc1, mlp_act, mlp_fc2 = self.mlp
+        x_parallel, _ = mlp_fc1(x)
+        x_parallel = mlp_act(x_parallel)
+        out, _ = mlp_fc2(x_parallel)
+        return out
+
+
+class Qwen2_5_VisionRotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, theta: float = 10000.0) -> None:
+        super().__init__()
+        self.dim = dim
+        self.theta = theta
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._freqs_cached: torch.Tensor = None  # type: ignore
+
+    def update_freqs_cache(self, seqlen: int) -> None:
+        if seqlen > self._seq_len_cached:
+            seqlen *= 2
+            self._seq_len_cached = seqlen
+            self.inv_freq = 1.0 / (
+                self.theta ** (torch.arange(0, self.dim, 2, dtype=torch.float, device=self.inv_freq.device) / self.dim)
+            )
+            seq = torch.arange(seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(seq, self.inv_freq)
+            self._freqs_cached = freqs
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        self.update_freqs_cache(seqlen)
+        return self._freqs_cached[:seqlen]
 
 
 class Qwen2_5_VisionTransformer(EricModel):
@@ -46,7 +316,7 @@ class Qwen2_5_VisionTransformer(EricModel):
                     dim=self.hidden_size,
                     num_heads=self.num_heads,
                     mlp_hidden_dim=vision_config.intermediate_size,
-                    act_fn=_ACTIVATION_REGISTRY[vision_config.hidden_act],
+                    act_fn=get_act_fn(vision_config.hidden_act),
                     norm_layer=norm_layer,
                 )
                 for layer_idx in range(depth)
@@ -58,7 +328,6 @@ class Qwen2_5_VisionTransformer(EricModel):
             norm_layer=norm_layer,
             spatial_merge_size=self.spatial_merge_size,
         )
-        self.attn_backend: _Backend = get_vit_attn_backend(support_fa=True)
 
     @property
     def dtype(self) -> torch.dtype:
@@ -138,22 +407,41 @@ class Qwen2_5_VisionTransformer(EricModel):
     def compute_attn_mask_seqlen(
         self,
         cu_seqlens: torch.Tensor,
-    ) -> tuple[Optional[int], Optional[list[int]]]:
+    ) -> tuple[int | None, list[int] | None]:
         max_seqlen, seqlens = None, None
-        if self.attn_backend == _Backend.FLASH_ATTN:
-            max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
-        elif self.attn_backend == _Backend.XFORMERS:
-            seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
         return max_seqlen, seqlens
 
     def forward(
         self,
-        x: torch.Tensor,
-        grid_thw: torch.Tensor,
-    ) -> torch.Tensor:
+        # x: torch.Tensor,
+        # grid_thw: torch.Tensor,
+        modality: Modality,
+        batch: dict[str, list[torch.Tensor]],
+    ) -> list[torch.Tensor]:
+        """Forward pass of the model.
+
+        For images, `batch` is expected to have the following keys:
+        - `pixel_values`: The pixel values of the images. Each [seq_len, 6 * patch_size (14) * patch_size (14)].
+        - `image_grid_thw`: The grid size of the images. Each [1, 3].
+
+        For videos, `batch` is expected to have the following keys:
+        - `pixel_values_videos`: The pixel values of the videos. Each [seq_len, 6 * patch_size (14) * patch_size (14)].
+        - `video_grid_thw`: The grid size of the videos. Each [1, 3].
+        """
+        # Batch
+        match modality:
+            case Modality.IMAGE:
+                pixel_values = torch.cat(batch["pixel_values"], dim=0).to(device=self.device, dtype=self.dtype)
+                grid_thw = torch.cat(batch["image_grid_thw"], dim=0).to(device=self.device)
+            case Modality.VIDEO:
+                pixel_values = torch.cat(batch["pixel_values_videos"], dim=0).to(device=self.device, dtype=self.dtype)
+                grid_thw = torch.cat(batch["video_grid_thw"], dim=0).to(device=self.device)
+            case _:
+                raise ValueError(f"Unsupported modality: {modality}")
+
         # patchify
-        hidden_states = x.to(device=self.device, dtype=self.dtype)
-        hidden_states = self.patch_embed(hidden_states)
+        hidden_states = self.patch_embed(pixel_values)
 
         # compute position embedding
         rotary_pos_emb = self.rot_pos_emb(grid_thw)
@@ -189,18 +477,15 @@ class Qwen2_5_VisionTransformer(EricModel):
             if layer_num in self.fullatt_block_indexes:
                 cu_seqlens_now = cu_seqlens
                 max_seqlen_now = max_seqlen_full
-                seqlens_now = seqlens_full
             else:
                 cu_seqlens_now = cu_window_seqlens
                 max_seqlen_now = max_seqlen_window
-                seqlens_now = seqlens_window
 
             hidden_states = blk(
                 hidden_states,
                 cu_seqlens=cu_seqlens_now,
                 rotary_pos_emb=rotary_pos_emb,
                 max_seqlen=max_seqlen_now,
-                seqlens=seqlens_now,
             )
 
         # For Qwen2.5-VL-3B, float16 will overflow at last block
@@ -212,4 +497,36 @@ class Qwen2_5_VisionTransformer(EricModel):
         hidden_states = self.merger(hidden_states)
         reverse_indices = torch.argsort(window_index)
         hidden_states = hidden_states[reverse_indices, :]
-        return hidden_states
+
+        # Unbatch
+        seqlens = (grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2]).squeeze(0) // self.spatial_merge_unit
+        result = hidden_states.squeeze(0).split(seqlens.tolist(), dim=0)
+
+        return result
+
+
+class ModalityProcessor(BaseModalityProcessor):
+    """Qwen2.5-VL modality processor."""
+
+    def __init__(self, model_id: str) -> None:
+        """Initialize the processor."""
+        super().__init__(model_id=model_id)
+        self.hf_processor = AutoImageProcessor.from_pretrained(model_id)
+
+    def get_image_processor(self) -> Callable | None:
+        """Return the image processor."""
+
+        def processor(image: npt.NDArray) -> dict[str, npt.NDArray]:
+            """Invoke the HF processor and convert to dict."""
+            return self.hf_processor(images=[image], return_tensors="np").data
+
+        return processor
+
+    def get_video_processor(self) -> Callable | None:
+        """Return the video processor."""
+
+        def processor(video: npt.NDArray) -> dict[str, npt.NDArray]:
+            """Invoke the HF processor and convert to dict."""
+            return self.hf_processor(images=None, videos=[video], return_tensors="np").data
+
+        return processor

--- a/python/cornserve/task_executors/eric/models/qwen2_vl.py
+++ b/python/cornserve/task_executors/eric/models/qwen2_vl.py
@@ -3,7 +3,6 @@
 from functools import partial
 from typing import Callable, Type
 
-from cornserve.task_executors.eric.schema import Modality
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -17,6 +16,7 @@ from flash_attn.layers.rotary import apply_rotary_emb
 from .base import EricModel
 from .layers.activations import QuickGELU
 from .layers.linear import ColumnParallelLinear, RowParallelLinear
+from cornserve.task_executors.eric.schema import Modality
 from cornserve.task_executors.eric.distributed import parallel
 from cornserve.task_executors.eric.router.processor import BaseModalityProcessor
 from cornserve.task_executors.eric.utils import distributed as dist_utils
@@ -292,10 +292,7 @@ class Qwen2VisionBlock(nn.Module):
 
 
 class Qwen2VisionTransformer(EricModel):
-    def __init__(
-        self,
-        config: Qwen2VLConfig,
-    ) -> None:
+    def __init__(self, config: Qwen2VLConfig) -> None:
         super().__init__()
         vision_config = config.vision_config
         patch_size = vision_config.patch_size

--- a/python/cornserve/task_executors/eric/models/registry.py
+++ b/python/cornserve/task_executors/eric/models/registry.py
@@ -89,6 +89,19 @@ MODEL_REGISTRY: dict[str, RegistryEntry] = {
             Modality.VIDEO: ModalityEntry(),
         },
     ),
+    "qwen2_5_vl": RegistryEntry(
+        module="qwen2_t_vl",
+        class_name="Qwen2_5_VisionTransformer",
+        vit_resolution_type=ViTResolutionType.DYNAMIC,
+        weight=WeightInfo(
+            required_prefixes=["visual."],
+            strip_prefixes=True,
+        ),
+        modality={
+            Modality.IMAGE: ModalityEntry(),
+            Modality.VIDEO: ModalityEntry(),
+        },
+    ),
     "llava_onevision": RegistryEntry(
         module="llava_onevision",
         class_name="LlavaOneVisionEncoder",

--- a/python/cornserve/task_executors/eric/models/registry.py
+++ b/python/cornserve/task_executors/eric/models/registry.py
@@ -90,7 +90,7 @@ MODEL_REGISTRY: dict[str, RegistryEntry] = {
         },
     ),
     "qwen2_5_vl": RegistryEntry(
-        module="qwen2_t_vl",
+        module="qwen2_5_vl",
         class_name="Qwen2_5_VisionTransformer",
         vit_resolution_type=ViTResolutionType.DYNAMIC,
         weight=WeightInfo(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -90,6 +90,7 @@ dev-common = [
   "ruff",
   "pytest",
   "pytest-asyncio",
+  "pytest-dependency",
   "cornserve[sidecar-api,gateway,resource-manager,task-manager,task-dispatcher]",
 ]
 dev = ["cornserve[dev-common,sidecar,eric]"]

--- a/python/tests/task_executors/eric/models/conftest.py
+++ b/python/tests/task_executors/eric/models/conftest.py
@@ -1,3 +1,8 @@
+import os
+import shutil
+import tempfile
+from collections.abc import Generator
+
 import pytest
 
 from cornserve.task_executors.eric.schema import Modality
@@ -28,3 +33,20 @@ TEST_VIDEO_URLS = [
 def test_videos() -> list[ModalityData]:
     """Fixture to provide test videos."""
     return [ModalityData(url=url, modality=Modality.VIDEO) for url in TEST_VIDEO_URLS]
+
+
+@pytest.fixture(scope="session")
+def dump_tensors() -> Generator[str, None, None]:
+    """Fixture to set `CORNSERVE_TEST_DUMP_TENSOR_DIR` environment variable."""
+    dir = os.getenv("CORNSERVE_TEST_DUMP_TENSOR_DIR")
+
+    # If unset, do it in a tempdir and clean up after the test session.
+    if dir is None:
+        tmp = os.environ["CORNSERVE_TEST_DUMP_TENSOR_DIR"] = tempfile.mkdtemp()
+        yield tmp
+        del os.environ["CORNSERVE_TEST_DUMP_TENSOR_DIR"]
+        shutil.rmtree(tmp)
+
+    # If explicitly set, use it and leave the stuff because the user would have intended to keep it.
+    else:
+        yield dir

--- a/python/tests/task_executors/eric/models/test_gemma3.py
+++ b/python/tests/task_executors/eric/models/test_gemma3.py
@@ -1,7 +1,5 @@
 """Tests for the Gemma3 model's vision encoder."""
 
-import os
-
 import pytest
 import torch
 from transformers.models.gemma3.modeling_gemma3 import Gemma3ForConditionalGeneration
@@ -12,15 +10,24 @@ from cornserve.task_executors.eric.executor.loader import load_model
 from cornserve.task_executors.eric.models.registry import MODEL_REGISTRY
 from cornserve.task_executors.eric.schema import Status
 
-from ..utils import ModalityData, assert_same_weights, batch_builder, param_tp_size
+from ..utils import (
+    TP_SIZES,
+    ModalityData,
+    assert_same_weights,
+    assert_similar,
+    batch_builder,
+    depends_on,
+    param_tp_size,
+)
 
 model_id = "google/gemma-3-4b-it"
+model_shorthand = "gemma3"
 
 
 def test_weight_loading() -> None:
     """Check if weights are loaded correctly."""
     # Hugging Face model output
-    hf_model = Gemma3ForConditionalGeneration.from_pretrained(model_id, torch_dtype="auto")
+    hf_model = Gemma3ForConditionalGeneration.from_pretrained(model_id, torch_dtype="auto").model
 
     # Load our model
     init_distributed(world_size=1, rank=0)
@@ -52,15 +59,42 @@ def test_weight_loading() -> None:
 
 
 @param_tp_size
-def test_image_inference(test_images: list[ModalityData], tp_size: int) -> None:
+def test_image_inference(test_images: list[ModalityData], tp_size: int, dump_tensors: str) -> None:
     """Test if inference works correctly."""
     executor = ModelExecutor(model_id=model_id, tp_size=tp_size, sender_sidecar_ranks=None)
 
-    result = executor.execute_model(batch=batch_builder(model_id, "gemma3", test_images))
+    result = executor.execute_model(batch=batch_builder(model_id, model_shorthand, test_images))
 
     assert result.status == Status.SUCCESS
 
     executor.shutdown()
+
+
+@depends_on("test_image_inference")
+def test_hf_reference(test_images: list[ModalityData], dump_tensors: str) -> None:
+    """Generate reference outputs from the Hugging Face model."""
+    torch.set_grad_enabled(False)
+
+    hf_model = Gemma3ForConditionalGeneration.from_pretrained(
+        model_id,
+        torch_dtype="auto",
+        attn_implementation="flash_attention_2",
+    )
+    model = hf_model.model.cuda().eval()
+
+    image1 = test_images[0].processed(model_id)
+    pixel_values = torch.asarray(image1["pixel_values"]).cuda()
+    output1 = model.get_image_features(pixel_values=pixel_values).cpu()
+
+    image2 = test_images[1].processed(model_id)
+    pixel_values = torch.asarray(image2["pixel_values"]).cuda()
+    output2 = model.get_image_features(pixel_values=pixel_values).cpu()
+
+    for tp_degree in TP_SIZES:
+        output = torch.load(f"{dump_tensors}/{model_shorthand}-image-tp{tp_degree}.pt")
+        assert_similar([output1, output2], output)
+
+    del output1, output2
 
 
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")

--- a/python/tests/task_executors/eric/models/test_llava_onevision.py
+++ b/python/tests/task_executors/eric/models/test_llava_onevision.py
@@ -2,7 +2,10 @@
 
 import pytest
 import torch
-from transformers.models.llava_onevision.modeling_llava_onevision import LlavaOnevisionForConditionalGeneration
+from transformers.models.llava_onevision.modeling_llava_onevision import (
+    LlavaOnevisionForConditionalGeneration,
+    LlavaOnevisionModel,
+)
 
 from cornserve.task_executors.eric.distributed.parallel import destroy_distributed, init_distributed
 from cornserve.task_executors.eric.executor.executor import ModelExecutor
@@ -10,15 +13,24 @@ from cornserve.task_executors.eric.executor.loader import load_model
 from cornserve.task_executors.eric.models.registry import MODEL_REGISTRY
 from cornserve.task_executors.eric.schema import Status
 
-from ..utils import ModalityData, assert_same_weights, batch_builder, param_tp_size
+from ..utils import (
+    TP_SIZES,
+    ModalityData,
+    assert_same_weights,
+    assert_similar,
+    batch_builder,
+    depends_on,
+    param_tp_size,
+)
 
 model_id = "llava-hf/llava-onevision-qwen2-7b-ov-chat-hf"
+model_shorthand = "onevision"
 
 
 def test_weight_loading() -> None:
     """Check if weights are loaded correctly."""
     # Hugging Face model output
-    hf_model = LlavaOnevisionForConditionalGeneration.from_pretrained(model_id, torch_dtype="auto")
+    hf_model = LlavaOnevisionForConditionalGeneration.from_pretrained(model_id, torch_dtype="auto").model
 
     # Load our model
     init_distributed(world_size=1, rank=0)
@@ -50,11 +62,11 @@ def test_weight_loading() -> None:
 
 
 @param_tp_size
-def test_image_inference(test_images: list[ModalityData], tp_size: int) -> None:
+def test_image_inference(test_images: list[ModalityData], tp_size: int, dump_tensors: str) -> None:
     """Test if inference works correctly."""
     executor = ModelExecutor(model_id=model_id, tp_size=tp_size, sender_sidecar_ranks=None)
 
-    result = executor.execute_model(batch=batch_builder(model_id, "onevision", test_images))
+    result = executor.execute_model(batch=batch_builder(model_id, model_shorthand, test_images))
 
     assert result.status == Status.SUCCESS
 
@@ -62,15 +74,98 @@ def test_image_inference(test_images: list[ModalityData], tp_size: int) -> None:
 
 
 @param_tp_size
-def test_video_inference(test_videos: list[ModalityData], tp_size: int) -> None:
+def test_video_inference(test_videos: list[ModalityData], tp_size: int, dump_tensors: str) -> None:
     """Test if inference works correctly."""
     executor = ModelExecutor(model_id=model_id, tp_size=tp_size, sender_sidecar_ranks=None)
 
-    result = executor.execute_model(batch=batch_builder(model_id, "onevision", test_videos[:2]))
+    result = executor.execute_model(batch=batch_builder(model_id, model_shorthand, test_videos[:2]))
 
     assert result.status == Status.SUCCESS
 
     executor.shutdown()
+
+
+@depends_on("test_image_inference", "test_video_inference")
+def test_hf_reference(test_images: list[ModalityData], test_videos: list[ModalityData], dump_tensors: str) -> None:
+    """Generate reference outputs from the Hugging Face model."""
+    torch.set_grad_enabled(False)
+
+    hf_model = LlavaOnevisionForConditionalGeneration.from_pretrained(
+        model_id,
+        torch_dtype="auto",
+        attn_implementation="flash_attention_2",
+    )
+    model: LlavaOnevisionModel = hf_model.model.cuda().eval()
+
+    image1 = test_images[0].processed(model_id)
+    pixel_values = torch.asarray(image1["pixel_values"]).cuda().unsqueeze(0)
+    image_sizes = torch.asarray(image1["image_sizes"]).cuda().unsqueeze(0)
+    image_features = model.get_image_features(
+        pixel_values,
+        image_sizes,
+        vision_feature_layer=model.config.vision_feature_layer,
+        vision_feature_select_strategy=model.config.vision_feature_select_strategy,
+    )
+    image_features, _ = model.pack_image_features(
+        image_features,
+        image_sizes,
+        image_newline=model.image_newline,
+        vision_aspect_ratio=model.config.vision_aspect_ratio,
+    )
+    output1 = image_features.cpu()
+
+    image2 = test_images[1].processed(model_id)
+    pixel_values = torch.asarray(image2["pixel_values"]).cuda().unsqueeze(0)
+    image_sizes = torch.asarray(image2["image_sizes"]).cuda().unsqueeze(0)
+    image_features = model.get_image_features(
+        pixel_values,
+        image_sizes,
+        vision_feature_layer=model.config.vision_feature_layer,
+        vision_feature_select_strategy=model.config.vision_feature_select_strategy,
+    )
+    image_features, _ = model.pack_image_features(
+        image_features,
+        image_sizes,
+        image_newline=model.image_newline,
+        vision_aspect_ratio=model.config.vision_aspect_ratio,
+    )
+    output2 = image_features.cpu()
+
+    for tp_degree in TP_SIZES:
+        output = torch.load(f"{dump_tensors}/{model_shorthand}-image-tp{tp_degree}.pt")
+        assert_similar([output1, output2], output)
+
+    del output1, output2
+
+    video1 = test_videos[0].processed(model_id)
+    pixel_values_videos = torch.asarray(video1["pixel_values_videos"]).cuda().unsqueeze(0)
+    video_features = model.get_video_features(
+        pixel_values_videos,
+        vision_feature_layer=model.config.vision_feature_layer,
+        vision_feature_select_strategy=model.config.vision_feature_select_strategy,
+    )
+    image_newline = model.image_newline[None, None, :].repeat(video_features.shape[0], 1, 1).to(video_features.device)
+    video_features = torch.cat((video_features, image_newline), dim=1)
+    video_features = video_features.flatten(0, 1)
+    output1 = video_features.cpu()
+
+    video2 = test_videos[1].processed(model_id)
+    pixel_values_videos = torch.asarray(video2["pixel_values_videos"]).cuda().unsqueeze(0)
+    video_features = model.get_video_features(
+        pixel_values_videos,
+        vision_feature_layer=model.config.vision_feature_layer,
+        vision_feature_select_strategy=model.config.vision_feature_select_strategy,
+    )
+    image_newline = model.image_newline[None, None, :].repeat(video_features.shape[0], 1, 1).to(video_features.device)
+    video_features = torch.cat((video_features, image_newline), dim=1)
+    video_features = video_features.flatten(0, 1)
+    output2 = video_features.cpu()
+
+    for tp_degree in TP_SIZES:
+        output = torch.load(f"{dump_tensors}/{model_shorthand}-video-tp{tp_degree}.pt")
+        assert_similar([output1, output2], output)
+
+    del output1, output2
 
 
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")

--- a/python/tests/task_executors/eric/models/test_qwen2_5_vl.py
+++ b/python/tests/task_executors/eric/models/test_qwen2_5_vl.py
@@ -11,9 +11,18 @@ from cornserve.task_executors.eric.executor.executor import ModelExecutor
 from cornserve.task_executors.eric.executor.loader import load_model
 from cornserve.task_executors.eric.schema import Status
 
-from ..utils import ModalityData, assert_same_weights, batch_builder, param_tp_size
+from ..utils import (
+    TP_SIZES,
+    ModalityData,
+    assert_same_weights,
+    assert_similar,
+    batch_builder,
+    depends_on,
+    param_tp_size,
+)
 
 model_id = "Qwen/Qwen2.5-VL-7B-Instruct"
+model_shorthand = "qwen2_5"
 
 
 def test_weight_loading() -> None:
@@ -31,11 +40,11 @@ def test_weight_loading() -> None:
 
 
 @param_tp_size
-def test_image_inference(test_images: list[ModalityData], tp_size: int) -> None:
+def test_image_inference(test_images: list[ModalityData], tp_size: int, dump_tensors: str) -> None:
     """Test if inference works correctly."""
     executor = ModelExecutor(model_id=model_id, tp_size=tp_size, sender_sidecar_ranks=None)
 
-    result = executor.execute_model(batch=batch_builder(model_id, "qwen2_5", test_images))
+    result = executor.execute_model(batch=batch_builder(model_id, model_shorthand, test_images))
 
     assert result.status == Status.SUCCESS
 
@@ -43,19 +52,19 @@ def test_image_inference(test_images: list[ModalityData], tp_size: int) -> None:
 
 
 @param_tp_size
-def test_video_inference(test_videos: list[ModalityData], tp_size: int) -> None:
+def test_video_inference(test_videos: list[ModalityData], tp_size: int, dump_tensors: str) -> None:
     """Test if inference works correctly."""
     executor = ModelExecutor(model_id=model_id, tp_size=tp_size, sender_sidecar_ranks=None)
 
-    result = executor.execute_model(batch=batch_builder(model_id, "qwen2_5", test_videos[:2]))
+    result = executor.execute_model(batch=batch_builder(model_id, model_shorthand, test_videos[:2]))
 
     assert result.status == Status.SUCCESS
 
     executor.shutdown()
 
 
-@pytest.mark.skipif(os.getenv("CORNSERVE_TEST_DUMP_TENSOR_DIR") is None, reason="Dump directory not set")
-def test_hf_reference(test_images: list[ModalityData], test_videos: list[ModalityData]) -> None:
+@depends_on("test_image_inference", "test_video_inference")
+def test_hf_reference(test_images: list[ModalityData], test_videos: list[ModalityData], dump_tensors: str) -> None:
     """Generate reference outputs from the Hugging Face model."""
     torch.set_grad_enabled(False)
 
@@ -69,27 +78,31 @@ def test_hf_reference(test_images: list[ModalityData], test_videos: list[Modalit
     image1 = test_images[0].processed(model_id)
     pixel_values = torch.asarray(image1["pixel_values"]).cuda()
     image_grid_thw = torch.asarray(image1["image_grid_thw"]).cuda()
-    output1 = model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw)
+    output1 = model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw).cpu()
 
     image2 = test_images[1].processed(model_id)
     pixel_values = torch.asarray(image2["pixel_values"]).cuda()
     image_grid_thw = torch.asarray(image2["image_grid_thw"]).cuda()
-    output2 = model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw)
+    output2 = model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw).cpu()
 
-    torch.save(
-        [output1.cpu(), output2.cpu()], os.path.join(os.getenv("CORNSERVE_TEST_DUMP_TENSOR_DIR"), "qwen2_5-hf_image.pt")
-    )
+    for tp_degree in TP_SIZES:
+        output = torch.load(f"{dump_tensors}/{model_shorthand}-image-tp{tp_degree}.pt")
+        assert_similar([output1, output2], output)
+
+    del output1, output2
 
     video1 = test_videos[0].processed(model_id)
     pixel_values_video = torch.asarray(video1["pixel_values_videos"]).cuda()
     video_grid_thw = torch.asarray(video1["video_grid_thw"]).cuda()
-    output1 = model.get_video_features(pixel_values_videos=pixel_values_video, video_grid_thw=video_grid_thw)
+    output1 = model.get_video_features(pixel_values_videos=pixel_values_video, video_grid_thw=video_grid_thw).cpu()
 
     video2 = test_videos[1].processed(model_id)
     pixel_values_video2 = torch.asarray(video2["pixel_values_videos"]).cuda()
     video_grid_thw2 = torch.asarray(video2["video_grid_thw"]).cuda()
-    output2 = model.get_video_features(pixel_values_videos=pixel_values_video2, video_grid_thw=video_grid_thw2)
+    output2 = model.get_video_features(pixel_values_videos=pixel_values_video2, video_grid_thw=video_grid_thw2).cpu()
 
-    torch.save(
-        [output1.cpu(), output2.cpu()], os.path.join(os.getenv("CORNSERVE_TEST_DUMP_TENSOR_DIR"), "qwen2_5-hf_video.pt")
-    )
+    for tp_degree in TP_SIZES:
+        output = torch.load(f"{dump_tensors}/{model_shorthand}-video-tp{tp_degree}.pt")
+        assert_similar([output1, output2], output)
+
+    del output1, output2

--- a/python/tests/task_executors/eric/models/test_qwen2_5_vl.py
+++ b/python/tests/task_executors/eric/models/test_qwen2_5_vl.py
@@ -1,0 +1,95 @@
+"""Tests for the Qwen2-VL model's vision encoder."""
+
+import os
+
+import pytest
+import torch
+from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import Qwen2_5_VLForConditionalGeneration
+
+from cornserve.task_executors.eric.distributed.parallel import destroy_distributed, init_distributed
+from cornserve.task_executors.eric.executor.executor import ModelExecutor
+from cornserve.task_executors.eric.executor.loader import load_model
+from cornserve.task_executors.eric.schema import Status
+
+from ..utils import ModalityData, assert_same_weights, batch_builder, param_tp_size
+
+model_id = "Qwen/Qwen2.5-VL-7B-Instruct"
+
+
+def test_weight_loading() -> None:
+    """Check if weights are loaded correctly."""
+    # Hugging Face model output
+    hf_model = Qwen2_5_VLForConditionalGeneration.from_pretrained(model_id, torch_dtype="auto").visual
+
+    # Load our model
+    init_distributed(world_size=1, rank=0)
+    our_model = load_model(model_id, torch_device=torch.device("cpu"))
+    destroy_distributed()
+
+    # Check if parameters are the same
+    assert_same_weights(hf_model, our_model)
+
+
+@param_tp_size
+def test_image_inference(test_images: list[ModalityData], tp_size: int) -> None:
+    """Test if inference works correctly."""
+    executor = ModelExecutor(model_id=model_id, tp_size=tp_size, sender_sidecar_ranks=None)
+
+    result = executor.execute_model(batch=batch_builder(model_id, "qwen2_5", test_images))
+
+    assert result.status == Status.SUCCESS
+
+    executor.shutdown()
+
+
+@param_tp_size
+def test_video_inference(test_videos: list[ModalityData], tp_size: int) -> None:
+    """Test if inference works correctly."""
+    executor = ModelExecutor(model_id=model_id, tp_size=tp_size, sender_sidecar_ranks=None)
+
+    result = executor.execute_model(batch=batch_builder(model_id, "qwen2_5", test_videos[:2]))
+
+    assert result.status == Status.SUCCESS
+
+    executor.shutdown()
+
+
+@pytest.mark.skipif(os.getenv("CORNSERVE_TEST_DUMP_TENSOR_DIR") is None, reason="Dump directory not set")
+def test_hf_reference(test_images: list[ModalityData], test_videos: list[ModalityData]) -> None:
+    """Generate reference outputs from the Hugging Face model."""
+    torch.set_grad_enabled(False)
+
+    hf_model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+        model_id,
+        torch_dtype="auto",
+        attn_implementation="flash_attention_2",
+    )
+    model = hf_model.model.cuda().eval()
+
+    image1 = test_images[0].processed(model_id)
+    pixel_values = torch.asarray(image1["pixel_values"]).cuda()
+    image_grid_thw = torch.asarray(image1["image_grid_thw"]).cuda()
+    output1 = model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw)
+
+    image2 = test_images[1].processed(model_id)
+    pixel_values = torch.asarray(image2["pixel_values"]).cuda()
+    image_grid_thw = torch.asarray(image2["image_grid_thw"]).cuda()
+    output2 = model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw)
+
+    torch.save(
+        [output1.cpu(), output2.cpu()], os.path.join(os.getenv("CORNSERVE_TEST_DUMP_TENSOR_DIR"), "qwen2_5-hf_image.pt")
+    )
+
+    video1 = test_videos[0].processed(model_id)
+    pixel_values_video = torch.asarray(video1["pixel_values_videos"]).cuda()
+    video_grid_thw = torch.asarray(video1["video_grid_thw"]).cuda()
+    output1 = model.get_video_features(pixel_values_videos=pixel_values_video, video_grid_thw=video_grid_thw)
+
+    video2 = test_videos[1].processed(model_id)
+    pixel_values_video2 = torch.asarray(video2["pixel_values_videos"]).cuda()
+    video_grid_thw2 = torch.asarray(video2["video_grid_thw"]).cuda()
+    output2 = model.get_video_features(pixel_values_videos=pixel_values_video2, video_grid_thw=video_grid_thw2)
+
+    torch.save(
+        [output1.cpu(), output2.cpu()], os.path.join(os.getenv("CORNSERVE_TEST_DUMP_TENSOR_DIR"), "qwen2_5-hf_video.pt")
+    )

--- a/python/tests/task_executors/eric/models/test_qwen2_vl.py
+++ b/python/tests/task_executors/eric/models/test_qwen2_vl.py
@@ -8,9 +8,18 @@ from cornserve.task_executors.eric.executor.executor import ModelExecutor
 from cornserve.task_executors.eric.executor.loader import load_model
 from cornserve.task_executors.eric.schema import Status
 
-from ..utils import ModalityData, assert_same_weights, batch_builder, param_tp_size
+from ..utils import (
+    TP_SIZES,
+    ModalityData,
+    assert_same_weights,
+    assert_similar,
+    batch_builder,
+    depends_on,
+    param_tp_size,
+)
 
 model_id = "Qwen/Qwen2-VL-7B-Instruct"
+model_shorthand = "qwen2"
 
 
 def test_weight_loading() -> None:
@@ -28,11 +37,11 @@ def test_weight_loading() -> None:
 
 
 @param_tp_size
-def test_image_inference(test_images: list[ModalityData], tp_size: int) -> None:
+def test_image_inference(test_images: list[ModalityData], tp_size: int, dump_tensors: str) -> None:
     """Test if inference works correctly."""
     executor = ModelExecutor(model_id=model_id, tp_size=tp_size, sender_sidecar_ranks=None)
 
-    result = executor.execute_model(batch=batch_builder(model_id, "qwen2", test_images))
+    result = executor.execute_model(batch=batch_builder(model_id, model_shorthand, test_images))
 
     assert result.status == Status.SUCCESS
 
@@ -40,12 +49,57 @@ def test_image_inference(test_images: list[ModalityData], tp_size: int) -> None:
 
 
 @param_tp_size
-def test_video_inference(test_videos: list[ModalityData], tp_size: int) -> None:
+def test_video_inference(test_videos: list[ModalityData], tp_size: int, dump_tensors: str) -> None:
     """Test if inference works correctly."""
     executor = ModelExecutor(model_id=model_id, tp_size=tp_size, sender_sidecar_ranks=None)
 
-    result = executor.execute_model(batch=batch_builder(model_id, "qwen2", test_videos[:2]))
+    result = executor.execute_model(batch=batch_builder(model_id, model_shorthand, test_videos[:2]))
 
     assert result.status == Status.SUCCESS
 
     executor.shutdown()
+
+
+@depends_on("test_image_inference", "test_video_inference")
+def test_hf_reference(test_images: list[ModalityData], test_videos: list[ModalityData], dump_tensors: str) -> None:
+    """Generate reference outputs from the Hugging Face model."""
+    torch.set_grad_enabled(False)
+
+    hf_model = Qwen2VLForConditionalGeneration.from_pretrained(
+        model_id,
+        torch_dtype="auto",
+        attn_implementation="flash_attention_2",
+    )
+    model = hf_model.model.cuda().eval()
+
+    image1 = test_images[0].processed(model_id)
+    pixel_values = torch.asarray(image1["pixel_values"]).cuda()
+    image_grid_thw = torch.asarray(image1["image_grid_thw"]).cuda()
+    output1 = model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw).cpu()
+
+    image2 = test_images[1].processed(model_id)
+    pixel_values = torch.asarray(image2["pixel_values"]).cuda()
+    image_grid_thw = torch.asarray(image2["image_grid_thw"]).cuda()
+    output2 = model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw).cpu()
+
+    for tp_degree in TP_SIZES:
+        output = torch.load(f"{dump_tensors}/{model_shorthand}-image-tp{tp_degree}.pt")
+        assert_similar([output1, output2], output)
+
+    del output1, output2
+
+    video1 = test_videos[0].processed(model_id)
+    pixel_values_video = torch.asarray(video1["pixel_values_videos"]).cuda()
+    video_grid_thw = torch.asarray(video1["video_grid_thw"]).cuda()
+    output1 = model.get_video_features(pixel_values_videos=pixel_values_video, video_grid_thw=video_grid_thw).cpu()
+
+    video2 = test_videos[1].processed(model_id)
+    pixel_values_video2 = torch.asarray(video2["pixel_values_videos"]).cuda()
+    video_grid_thw2 = torch.asarray(video2["video_grid_thw"]).cuda()
+    output2 = model.get_video_features(pixel_values_videos=pixel_values_video2, video_grid_thw=video_grid_thw2).cpu()
+
+    for tp_degree in TP_SIZES:
+        output = torch.load(f"{dump_tensors}/{model_shorthand}-video-tp{tp_degree}.pt")
+        assert_similar([output1, output2], output)
+
+    del output1, output2

--- a/python/tests/task_executors/eric/utils.py
+++ b/python/tests/task_executors/eric/utils.py
@@ -16,7 +16,6 @@ from cornserve.task_executors.eric.config import ImageDataConfig, ModalityConfig
 from cornserve.task_executors.eric.router.processor import Processor
 from cornserve.task_executors.eric.schema import Modality, WorkerBatch
 
-DUMP_DIR = os.getenv("CORNSERVE_TEST_DUMP_TENSOR_DIR", None)
 TEST_NUM_GPUS: list[int] = [1, 2, 4, 8]
 
 try:
@@ -29,10 +28,30 @@ except subprocess.CalledProcessError:
     CURR_NUM_GPUS = 0
 
 
+TP_SIZES = [tp for tp in [1, 2, 4, 8] if tp <= CURR_NUM_GPUS]
+
+
 def param_tp_size(func):
     """Parametrize test argument `tp_size` with power-of-two TP degrees."""
-    sizes = [ts for ts in (1, 2, 4, 8) if ts <= CURR_NUM_GPUS]
-    return pytest.mark.parametrize("tp_size", sizes, ids=lambda x: f"TP={x}")(func)
+    func = pytest.mark.parametrize(
+        "tp_size",
+        TP_SIZES,
+        ids=lambda x: f"TP={x}",
+    )(func)
+    return pytest.mark.dependency()(func)
+
+
+def depends_on(*names: str):
+    """Decorator that marks a test to depend on TP-parameterized tests."""
+
+    def wrapper(func):
+        depends = []
+        for name in names:
+            for tp in TP_SIZES:
+                depends.append(f"{name}[TP={tp}]")
+        return pytest.mark.dependency(depends=depends)(func)
+
+    return wrapper
 
 
 class ModalityData:
@@ -95,13 +114,38 @@ def assert_same_weights(
         assert param.shape == hf_param.shape, name
         assert torch.allclose(param, hf_param), name
 
+    print(f"{dict(hf_model.named_parameters()).keys()=}")
     hf_params = filter_weight_dict(dict(hf_model.named_parameters()))
     our_params = filter_weight_dict(dict(our_model.named_parameters()))
     if not transformed_weights:
         assert len(hf_params) == len(our_params)
 
+    print(f"{hf_params.keys()=}")
+    print(f"{our_params.keys()=}")
     for name, param in our_params.items():
         check_param(name, param, hf_params)
+
+
+def assert_similar(*args: list[torch.Tensor]) -> None:
+    """Asserts that all tensors in the same position across the lists are similar.
+
+    Similar is defined as having a cosine similarity greater than 0.98.
+    """
+    # Make sure all lists are of the same length
+    assert all(len(arg) == len(args[0]) for arg in args), "All input lists must have the same length."
+    n = len(args[0])
+
+    for i in range(n):
+        # Get the tensors at position i from all lists
+        tensors = [arg[i] for arg in args]
+
+        for j in range(len(tensors)):
+            for k in range(j + 1, len(tensors)):
+                # Calculate cosine similarity
+                cos_sim = torch.cosine_similarity(tensors[j], tensors[k]).mean().item()
+                assert cos_sim > 0.98, (
+                    f"Cosine similarity between tensors {j} and {k} at index {i} is too low: {cos_sim}"
+                )
 
 
 def batch_builder(model_id: str, nickname: str, data: list[ModalityData]) -> WorkerBatch:
@@ -124,7 +168,8 @@ def batch_builder(model_id: str, nickname: str, data: list[ModalityData]) -> Wor
         otel_carriers=[None for _ in data],
     )
 
-    if DUMP_DIR is not None:
-        batch._dump_prefix = f"{DUMP_DIR}/{nickname}-{modality.value}"
+    if (dump_dir := os.getenv("CORNSERVE_TEST_DUMP_TENSOR_DIR")) is not None:
+        # If the environment variable is set, use it to set the dump prefix
+        batch._dump_prefix = f"{dump_dir}/{nickname}-{modality.value}"
 
     return batch

--- a/python/tests/task_executors/eric/utils.py
+++ b/python/tests/task_executors/eric/utils.py
@@ -114,14 +114,11 @@ def assert_same_weights(
         assert param.shape == hf_param.shape, name
         assert torch.allclose(param, hf_param), name
 
-    print(f"{dict(hf_model.named_parameters()).keys()=}")
     hf_params = filter_weight_dict(dict(hf_model.named_parameters()))
     our_params = filter_weight_dict(dict(our_model.named_parameters()))
     if not transformed_weights:
         assert len(hf_params) == len(our_params)
 
-    print(f"{hf_params.keys()=}")
-    print(f"{our_params.keys()=}")
     for name, param in our_params.items():
         check_param(name, param, hf_params)
 


### PR DESCRIPTION
This PR implements image and video encoders for Qwen 2.5 VL, which are also used on Qwen 2.5 Omni.

Plus, I've added correctness tests for all Eric models that embeds the same images and videos (two each) with HuggingFace transformers and Eric (TP 1, 2, and 4) and asserts cosine similarity between outputs.

Unexpectedly, the test passes for LLaVA OneVision as well. I'm not sure what's going on.