### PR TITLE
[Fix] OTEL Dependency Conflict

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
   "kubernetes_asyncio",
   "httpx",
   "pydantic>=2.11",
-  "opentelemetry-api",
-  "opentelemetry-sdk",
-  "opentelemetry-exporter-otlp-proto-grpc",
+  "opentelemetry-api>=1.33.1",
+  "opentelemetry-sdk>=1.33.1",
+  "opentelemetry-exporter-otlp-proto-grpc>=1.33.1",
   "websocket-client",
 ]
 dynamic = ["version"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,16 +19,16 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-  "grpcio-tools",
+  "grpcio-tools==1.71.0",
   "rich",
   "requests",
   "tyro",
   "kubernetes_asyncio",
   "httpx",
   "pydantic>=2.11",
-  "opentelemetry-api>=1.33.1",
-  "opentelemetry-sdk>=1.33.1",
-  "opentelemetry-exporter-otlp-proto-grpc>=1.33.1",
+  "opentelemetry-api",
+  "opentelemetry-sdk",
+  "opentelemetry-exporter-otlp-proto-grpc",
   "websocket-client",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Now, newly-built component containers (like gateway) error out immediately upon entry, due to an issue of obsolete otel packages versions, more details below. Specifying lowest version numbers fixes that issue. Still trying to understand why this happens.


More about the issue:
For some reason, now newly-built containers would have very low (0.x) otel package versions, which lead to an error when cornserve python components try to import otel. For example, in the gateway container:
```
Python 3.11.11 (main, Apr  8 2025, 04:27:35) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import opentelemetry.exporter.otlp.proto.grpc.trace_exporter
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/site-packages/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py", line 22, in <module>
    from opentelemetry.exporter.otlp.proto.grpc.exporter import (
  File "/usr/local/lib/python3.11/site-packages/opentelemetry/exporter/otlp/proto/grpc/exporter.py", line 39, in <module>
    from opentelemetry.proto.common.v1.common_pb2 import (
  File "/usr/local/lib/python3.11/site-packages/opentelemetry/proto/common/v1/common_pb2.py", line 36, in <module>
    _descriptor.FieldDescriptor(
  File "/usr/local/lib/python3.11/site-packages/google/protobuf/descriptor.py", line 621, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```
But specifying a version in pyproject.toml fixes that. One guess for the root-cause is that, other python packages now transiently depends on an older version of otel, but after checking the dependency tree of all packages in the container's env, this is not the case.