### PR TITLE
[Eric] Qwen 2.5 Omni encoders

### DIFF
--- a/.github/workflows/push_docker.yaml
+++ b/.github/workflows/push_docker.yaml
@@ -40,7 +40,7 @@ jobs:
           - component: eric
             build_args: |
               max_jobs=4
-              build_target=eric
+            build_target: eric
 
     steps:
       - name: Remove unnecessary files

--- a/.github/workflows/push_docker.yaml
+++ b/.github/workflows/push_docker.yaml
@@ -40,6 +40,7 @@ jobs:
           - component: eric
             build_args: |
               max_jobs=4
+              build_target=eric
 
     steps:
       - name: Remove unnecessary files
@@ -96,3 +97,4 @@ jobs:
           cache-to: type=registry,ref=${{ env.NAMESPACE }}/${{ matrix.component }}:buildcache,mode=max
           platforms: linux/amd64
           build-args: ${{ matrix.build_args }}
+          target: ${{ matrix.build_target || '' }}

--- a/docker/eric-audio.Dockerfile
+++ b/docker/eric-audio.Dockerfile
@@ -1,6 +1,0 @@
-# We have a seaprate Dockerfile due to license issues with the audio package.
-# Users who need audio support in Eric should read and accept their license terms,
-# build this image separately, and tag it as `cornserve/eric` so that it's picked up.
-FROM cornserve/eric:latest
-
-RUN pip install -e '.[audio]'

--- a/docker/eric-audio.Dockerfile
+++ b/docker/eric-audio.Dockerfile
@@ -1,0 +1,6 @@
+# We have a seaprate Dockerfile due to license issues with the audio package.
+# Users who need audio support in Eric should read and accept their license terms,
+# build this image separately, and tag it as `cornserve/eric` so that it's picked up.
+FROM cornserve/eric:latest
+
+RUN pip install -e '.[audio]'

--- a/docker/eric.Dockerfile
+++ b/docker/eric.Dockerfile
@@ -24,6 +24,6 @@ RUN pip install -e '.[eric]'
 ENTRYPOINT ["python", "-u", "-m", "cornserve.task_executors.eric.entrypoint"]
 
 # Eric that has audio support.
-FROM eric-runtime AS eric-audio
+FROM eric AS eric-audio
 
 RUN pip install -e '.[audio]'

--- a/docker/eric.Dockerfile
+++ b/docker/eric.Dockerfile
@@ -7,7 +7,7 @@ ENV NVCC_THREADS=8
 RUN pip wheel -w /tmp/wheels --no-build-isolation --no-deps --verbose flash-attn
 
 # Actual Eric runs inside the `runtime` image. Just copy over the flash-attn wheel.
-FROM pytorch/pytorch:2.7.0-cuda12.6-cudnn9-runtime AS runtime
+FROM pytorch/pytorch:2.7.0-cuda12.6-cudnn9-runtime AS eric
 
 COPY --from=builder /tmp/wheels/*.whl /tmp/wheels/
 RUN pip install --no-cache-dir /tmp/wheels/*.whl && rm -rf /tmp/wheels
@@ -22,3 +22,8 @@ WORKDIR /workspace/cornserve/python
 RUN pip install -e '.[eric]'
 
 ENTRYPOINT ["python", "-u", "-m", "cornserve.task_executors.eric.entrypoint"]
+
+# Eric that has audio support.
+FROM eric-runtime AS eric-audio
+
+RUN pip install -e '.[audio]'

--- a/python/cornserve/task/builtins/encoder.py
+++ b/python/cornserve/task/builtins/encoder.py
@@ -13,6 +13,7 @@ class Modality(enum.StrEnum):
 
     IMAGE = "image"
     VIDEO = "video"
+    AUDIO = "audio"
 
 
 class EncoderInput(TaskInput):

--- a/python/cornserve/task/builtins/llm.py
+++ b/python/cornserve/task/builtins/llm.py
@@ -14,7 +14,7 @@ class LLMInput(TaskInput):
     Attributes:
         prompt: The prompt to send to the LLM.
         multimodal_data: List of tuples (modality, data URL).
-            "image", "video", etc. for modality.
+            "image", "audio", "video", etc. for modality.
         embeddings: Multimodal embeddings to send to the LLM.
     """
 

--- a/python/cornserve/task/builtins/mllm.py
+++ b/python/cornserve/task/builtins/mllm.py
@@ -14,7 +14,7 @@ class MLLMInput(TaskInput):
     Attributes:
         prompt: The prompt to send to the LLM.
         multimodal_data: List of tuples (modality, data URL).
-            "image", "video", etc. for modality.
+            "image", "audio", "video", etc. for modality.
     """
 
     prompt: str

--- a/python/cornserve/task_executors/descriptor/builtins/encoder.py
+++ b/python/cornserve/task_executors/descriptor/builtins/encoder.py
@@ -40,6 +40,7 @@ class EricDescriptor(TaskExecutionDescriptor[EncoderTask, EncoderInput, EncoderO
         cmd = [
             "--model.id", self.task.model_id,
             "--model.tp-size", str(len(gpus)),
+            "--model.modality", self.task.modality.value,
             "--server.port", str(port),
             "--sidecar.ranks", *[str(gpu.global_rank) for gpu in gpus],
         ]

--- a/python/cornserve/task_executors/eric/api.py
+++ b/python/cornserve/task_executors/eric/api.py
@@ -14,6 +14,7 @@ class Modality(enum.StrEnum):
 
     IMAGE = "image"
     VIDEO = "video"
+    AUDIO = "audio"
 
 
 class EmbeddingData(BaseModel):

--- a/python/cornserve/task_executors/eric/config.py
+++ b/python/cornserve/task_executors/eric/config.py
@@ -2,7 +2,7 @@
 
 Config values will be supplied by the Task Manager when Eric is launched.
 
-Config values should be kept in sync with `cornserve.task_executors.launch`.
+Config values should be kept in sync with the built-in `EricDescriptor`.
 """
 
 from __future__ import annotations
@@ -12,6 +12,9 @@ from typing import Self
 from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt, model_validator
 from transformers.configuration_utils import PretrainedConfig
 from transformers.models.auto.configuration_auto import AutoConfig
+from transformers.models.auto.processing_auto import AutoProcessor
+
+from cornserve.task_executors.eric.api import Modality
 
 
 class ModelConfig(BaseModel):
@@ -22,6 +25,9 @@ class ModelConfig(BaseModel):
 
     # Tensor parallel degree
     tp_size: PositiveInt = 1
+
+    # Modality type
+    modality: Modality
 
     # HF config
     # This will be replaced with the real HF config of the model ID
@@ -69,6 +75,12 @@ class VideoDataConfig(BaseModel):
 class AudioDataConfig(BaseModel):
     """Configuration related to downloading and processing audio data."""
 
+    # Sampling rate to use when loading audio data.
+    # When the server is configured to embed audio data, this will be
+    # populated from the HF AutoProcessor's attribute so match the model's
+    # expected sampling rate.
+    sampling_rate: PositiveInt | None = None
+
 
 class ModalityConfig(BaseModel):
     """Modality processing config."""
@@ -111,11 +123,28 @@ class EricConfig(BaseModel):
 
     @model_validator(mode="after")
     def validator(self) -> Self:
-        """Audit the config for correctness."""
+        """Audit the config for correctness and apply any transformations."""
         if self.model.tp_size != len(self.sidecar.ranks):
             raise ValueError(
                 f"Tensor parallel rank ({self.model.tp_size}) "
                 f"must match number of sender sidecar ranks ({self.sidecar.ranks})"
             )
+
+        if self.model.modality == Modality.AUDIO and self.modality.audio_config.sampling_rate is None:
+            processor = AutoProcessor.from_pretrained(self.model.id)
+            feature_extractor = getattr(processor, "feature_extractor", None)
+            if feature_extractor is None:
+                raise ValueError(
+                    "In order to determine the audio sampling rate, we attempted to "
+                    "access the HF AutoProcessor's `feature_extractor`, but it didn't exist."
+                )
+            sampling_rate = getattr(feature_extractor, "sampling_rate", None)
+            if sampling_rate is None:
+                raise ValueError(
+                    "In order to determine the audio sampling rate, we attempted to "
+                    "access the HF AutoProcessor's `feature_extractor.sampling_rate`, "
+                    "but it didn't exist."
+                )
+            self.modality.audio_config.sampling_rate = sampling_rate
 
         return self

--- a/python/cornserve/task_executors/eric/config.py
+++ b/python/cornserve/task_executors/eric/config.py
@@ -66,6 +66,10 @@ class VideoDataConfig(BaseModel):
     max_num_frames: PositiveInt | None = 32
 
 
+class AudioDataConfig(BaseModel):
+    """Configuration related to downloading and processing audio data."""
+
+
 class ModalityConfig(BaseModel):
     """Modality processing config."""
 
@@ -77,6 +81,9 @@ class ModalityConfig(BaseModel):
 
     # Video-specific processor config
     video_config: VideoDataConfig = VideoDataConfig()
+
+    # Audio-specific processor config
+    audio_config: AudioDataConfig = AudioDataConfig()
 
     @model_validator(mode="after")
     def validator(self) -> Self:

--- a/python/cornserve/task_executors/eric/distributed/parallel.py
+++ b/python/cornserve/task_executors/eric/distributed/parallel.py
@@ -13,6 +13,13 @@ class DeviceGroup:
     """A group of devices bound by a common process group.
 
     `torch.distributed` should be initialized before creating a device group.
+
+    Attributes:
+        rank (int): The rank of the current process in the device group.
+        world_size (int): The number of ranks in the device group.
+        process_group (ProcessGroup | None): The PyTorch distributed
+            process group associated with this device group.
+        device_mesh (DeviceMesh | None): The device mesh for this group.
     """
 
     def __init__(self, ranks: list[int], name: str) -> None:
@@ -27,6 +34,7 @@ class DeviceGroup:
         self.world_size = len(ranks)
 
         if self.world_size == 1:
+            self.device_mesh = None
             self.process_group = None
             self.rank = 0
             return
@@ -34,8 +42,13 @@ class DeviceGroup:
         if not torch.distributed.is_initialized():
             raise RuntimeError(f"Distributed process group is not initialized. Cannot create device group {name}.")
 
-        self.process_group = torch.distributed.new_group(ranks=ranks)
-        self.rank = torch.distributed.get_rank(self.process_group)
+        self.device_mesh = torch.distributed.device_mesh.init_device_mesh(
+            device_type="cuda",
+            mesh_shape=(self.world_size,),
+            mesh_dim_names=("tp",),
+        )
+        self.process_group = self.device_mesh.get_group("tp")
+        self.rank = self.device_mesh.get_local_rank("tp")
 
         logger.info(
             "Device group %s initialized with ranks %s and world size %d.",

--- a/python/cornserve/task_executors/eric/distributed/parallel.py
+++ b/python/cornserve/task_executors/eric/distributed/parallel.py
@@ -57,12 +57,6 @@ class DeviceGroup:
             self.world_size,
         )
 
-    def shutdown(self) -> None:
-        """Shutdown the device group."""
-        if self.process_group is not None:
-            torch.distributed.destroy_process_group(self.process_group)
-            logger.info("Device group %s destroyed.", self.name)
-
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
         """Perform AllGather on the tensor across the device group.
 
@@ -178,6 +172,5 @@ def destroy_distributed() -> None:
         logger.warning("Distributed process group is not initialized. Skipping destruction.")
         return
 
-    get_tensor_parallel_group().shutdown()
     torch.distributed.destroy_process_group()
     logger.info("Uninitialized distributed process groups.")

--- a/python/cornserve/task_executors/eric/models/base.py
+++ b/python/cornserve/task_executors/eric/models/base.py
@@ -58,34 +58,46 @@ class BaseModalityProcessor:
         self.model_id = model_id
 
     def get_image_processor(self) -> Callable | None:
-        """Get the image processor for this modality."""
+        """Get the image processor for this modality.
+
+        The callable sould take a single image numpy array.
+        """
         return None
 
     def get_audio_processor(self) -> Callable | None:
-        """Get the audio processor for this modality."""
+        """Get the audio processor for this modality.
+
+        The callable should take a tuple of (audio data numpy array, sample rate).
+        """
         return None
 
     def get_video_processor(self) -> Callable | None:
-        """Get the video processor for this modality."""
+        """Get the video processor for this modality.
+
+        The callable should take a single video numpy array.
+        """
         return None
 
-    def process(self, modality: Modality, data: npt.NDArray) -> dict[str, npt.NDArray]:
+    def process(self, modality: Modality, data: tuple) -> dict[str, npt.NDArray]:
         """Process the input data for the given modality."""
         match modality:
             case Modality.IMAGE:
                 image_processor = self.get_image_processor()
                 if image_processor is None:
                     raise ValueError("Image processor not available.")
-                return image_processor(data)
+                assert len(data) == 1, "Expected a tuple with a single image numpy array."
+                return image_processor(*data)
             case Modality.AUDIO:
                 audio_processor = self.get_audio_processor()
                 if audio_processor is None:
                     raise ValueError("Audio processor not available.")
-                return audio_processor(data)
+                assert len(data) == 2, "Expected a tuple with audio data numpy array and sample rate."
+                return audio_processor(*data)
             case Modality.VIDEO:
                 video_processor = self.get_video_processor()
                 if video_processor is None:
                     raise ValueError("Video processor not available.")
-                return video_processor(data)
+                assert len(data) == 1, "Expected a tuple with a single video numpy array."
+                return video_processor(*data)
             case _:
                 raise ValueError(f"Unsupported modality: {modality}")

--- a/python/cornserve/task_executors/eric/models/base.py
+++ b/python/cornserve/task_executors/eric/models/base.py
@@ -61,6 +61,10 @@ class BaseModalityProcessor:
         """Get the image processor for this modality."""
         return None
 
+    def get_audio_processor(self) -> Callable | None:
+        """Get the audio processor for this modality."""
+        return None
+
     def get_video_processor(self) -> Callable | None:
         """Get the video processor for this modality."""
         return None
@@ -73,6 +77,11 @@ class BaseModalityProcessor:
                 if image_processor is None:
                     raise ValueError("Image processor not available.")
                 return image_processor(data)
+            case Modality.AUDIO:
+                audio_processor = self.get_audio_processor()
+                if audio_processor is None:
+                    raise ValueError("Audio processor not available.")
+                return audio_processor(data)
             case Modality.VIDEO:
                 video_processor = self.get_video_processor()
                 if video_processor is None:

--- a/python/cornserve/task_executors/eric/models/base.py
+++ b/python/cornserve/task_executors/eric/models/base.py
@@ -50,7 +50,8 @@ class BaseModalityProcessor:
     inherits from this class. It should override `get_image_processor`,
     `get_video_processor`, etc. to return the appropriate processor for the
     given modality. The processor should be a callable that takes the input
-    modality data as a Numpy array and returns the processed data as
+    modality data as a Numpy array and returns the processed data as a
+    dictionary of Numpy arrays.
     """
 
     def __init__(self, model_id: str) -> None:
@@ -78,26 +79,23 @@ class BaseModalityProcessor:
         """
         return None
 
-    def process(self, modality: Modality, data: tuple) -> dict[str, npt.NDArray]:
+    def process(self, modality: Modality, data: npt.NDArray) -> dict[str, npt.NDArray]:
         """Process the input data for the given modality."""
         match modality:
             case Modality.IMAGE:
                 image_processor = self.get_image_processor()
                 if image_processor is None:
                     raise ValueError("Image processor not available.")
-                assert len(data) == 1, "Expected a tuple with a single image numpy array."
-                return image_processor(*data)
+                return image_processor(data)
             case Modality.AUDIO:
                 audio_processor = self.get_audio_processor()
                 if audio_processor is None:
                     raise ValueError("Audio processor not available.")
-                assert len(data) == 2, "Expected a tuple with audio data numpy array and sample rate."
-                return audio_processor(*data)
+                return audio_processor(data)
             case Modality.VIDEO:
                 video_processor = self.get_video_processor()
                 if video_processor is None:
                     raise ValueError("Video processor not available.")
-                assert len(data) == 1, "Expected a tuple with a single video numpy array."
-                return video_processor(*data)
+                return video_processor(data)
             case _:
                 raise ValueError(f"Unsupported modality: {modality}")

--- a/python/cornserve/task_executors/eric/models/qwen2_5_omni.py
+++ b/python/cornserve/task_executors/eric/models/qwen2_5_omni.py
@@ -1,0 +1,240 @@
+from functools import partial
+from typing import Callable
+
+import torch
+import numpy.typing as npt
+from torch import nn
+from einops import rearrange
+from transformers.models.auto.processing_auto import AutoProcessor
+from transformers.models.qwen2_5_omni.configuration_qwen2_5_omni import Qwen2_5OmniConfig
+from transformers.models.qwen2_5_omni.modeling_qwen2_5_omni import Qwen2_5OmniAudioEncoder
+from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import Qwen2_5_VLConfig, Qwen2_5_VLVisionConfig
+from flash_attn import flash_attn_varlen_func
+from flash_attn.layers.rotary import apply_rotary_emb
+
+from . import qwen2_5_vl
+from .base import EricModel
+from .layers.linear import RowParallelLinear, QKVParallelLinear
+from cornserve.task_executors.eric.api import Modality
+from cornserve.task_executors.eric.distributed import parallel
+from cornserve.task_executors.eric.router.processor import BaseModalityProcessor
+from cornserve.task_executors.eric.utils import distributed as dist_utils
+
+
+def apply_rotary_pos_emb_vision(t: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
+    t_ = t.float()
+    cos = freqs.cos()
+    sin = freqs.sin()
+
+    output = apply_rotary_emb(t_, cos, sin).type_as(t)
+
+    return output
+
+
+class Qwen2_5_VisionAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        projection_size: int,
+    ) -> None:
+        super().__init__()
+        # Per attention head and per partition values.
+        self.tp_group = parallel.get_tensor_parallel_group()
+        self.tp_size = self.tp_group.world_size
+        self.tp_rank = self.tp_group.rank
+        self.hidden_size_per_attention_head = dist_utils.divide(projection_size, num_heads)
+        self.num_attention_heads_per_partition = dist_utils.divide(num_heads, self.tp_size)
+        self.embed_dim = embed_dim
+
+        # self.qkv = ColumnParallelLinear(input_size=embed_dim, output_size=3 * projection_size)
+        self.qkv = QKVParallelLinear(
+            hidden_size=embed_dim,
+            head_size=self.hidden_size_per_attention_head,
+            total_num_heads=num_heads,
+            total_num_kv_heads=num_heads,
+            bias=True,
+            gather_from_names=("q", "k", "v"),
+        )
+        self.proj = RowParallelLinear(input_size=projection_size, output_size=embed_dim)
+
+    def split_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        # [s, b, 3 * head * head_dim]
+        seq_len, bs, _ = qkv.shape
+        if self.tp_size > 1:
+            # qkv = all_gather_interleave(qkv, self.embed_dim, self.tp_size)
+            qkv = self.tp_group.all_gather(qkv)
+
+        # [s, b, 3 * head * head_dim] -> 3 * [s, b, head * head_dim]
+        q, k, v = qkv.chunk(3, dim=2)
+
+        # 3 * [s, b, head * head_dim]
+        if self.tp_size > 1:
+            splitter = partial(dist_utils.split_tensor_along_last_dim, num_partitions=self.tp_size)
+            q = splitter(q)[self.tp_rank]
+            k = splitter(k)[self.tp_rank]
+            v = splitter(v)[self.tp_rank]
+
+        # 3 * [s, b, head * head_dim] -> 3 * [s, b, head, head_dim]
+        new_shape = (seq_len, bs, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
+        q, k, v = (x.view(*new_shape) for x in (q, k, v))
+        return q, k, v
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb: torch.Tensor,
+        max_seqlen: int | None = None,  # Only used for Flash Attention
+    ) -> torch.Tensor:
+        # [s, b, c] --> [s, b, head * 3 * head_dim]
+        x, _ = self.qkv(x)
+
+        # [s, b, 3 * head * head_dim] -> 3 * [s, b, head, head_dim]
+        q, k, v = self.split_qkv(x)
+        batch_size = q.shape[1]
+
+        q, k, v = (rearrange(x, "s b ... -> b s ...").contiguous() for x in (q, k, v))
+        if rotary_pos_emb is not None:
+            q = apply_rotary_pos_emb_vision(q, rotary_pos_emb)
+            k = apply_rotary_pos_emb_vision(k, rotary_pos_emb)
+
+        # from vllm_flash_attn.flash_attn_interface import (
+        #   flash_attn_varlen_func)
+
+        q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
+
+        output = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_k=max_seqlen,
+            dropout_p=0,
+            causal=False,
+        )
+
+        context_layer = rearrange(output, "(b s) ... -> b s ...", b=batch_size)
+        context_layer = rearrange(context_layer, "b s h d -> s b (h d)").contiguous()
+
+        output, _ = self.proj(context_layer)
+        return output
+
+
+# Patch the Qwen2_5_VisionAttention class in the qwen2_5_vl module.
+# The only difference is that this one uses `QKVParallelLinear` instead of `ColumnParallelLinear`,
+# because the Omni model's checkpoint saved Q, K, nad V separately.
+qwen2_5_vl.Qwen2_5_VisionAttention = Qwen2_5_VisionAttention
+
+
+class Qwen2_5OmniEncoder(EricModel):
+    def __init__(self, config: Qwen2_5OmniConfig) -> None:
+        super().__init__()
+
+        self.config = config
+
+        vision_config = Qwen2_5_VLConfig()
+        vision_config.vision_config = Qwen2_5_VLVisionConfig(
+            **config.thinker_config.vision_config.to_dict(),
+        )
+        vision_config.rms_norm_eps = getattr(config.thinker_config.text_config, "rms_norm_eps", 1e-6)
+        self.visual = qwen2_5_vl.Qwen2_5_VisionTransformer(vision_config)
+
+        # TODO(J1): Explore parallelizing with parallelize_module.
+        audio_config = config.thinker_config.audio_config
+        audio_config._attn_implementation_autoset = True
+        audio_config._attn_implementation = "flash_attention_2"
+        self.audio_tower = Qwen2_5OmniAudioEncoder(audio_config)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.visual.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.visual.device
+
+    @property
+    def chunk_shape(self) -> tuple[int, ...]:
+        return (1, self.visual.out_hidden_size)
+
+    def forward(
+        self,
+        modality: Modality,
+        batch: dict[str, list[torch.Tensor]],
+    ) -> list[torch.Tensor]:
+        raise NotImplementedError(f"Modality {modality} is not supported by {self.__class__.__name__}.")
+
+
+class ModalityProcessor(BaseModalityProcessor):
+    """Qwen2.5-Omni modality processor."""
+
+    def __init__(self, model_id: str) -> None:
+        """Initialize the processor."""
+        super().__init__(model_id=model_id)
+        self.hf_processor = AutoProcessor.from_pretrained(model_id)
+
+    def get_image_processor(self) -> Callable | None:
+        """Return the image processor."""
+        # TODO(J1): Time to do the processing part. Look at vLLM.
+
+        if images is not None:
+            images_inputs = self.image_processor(images=images, videos=None, **output_kwargs["images_kwargs"])
+            image_grid_thw = iter(images_inputs["image_grid_thw"])
+        else:
+            images_inputs = {}
+            image_grid_thw = iter([])
+
+        def processor(image: npt.NDArray) -> dict[str, npt.NDArray]:
+            """Invoke the HF processor and convert to dict."""
+            return self.hf_processor(images=[image], return_tensors="np").data
+
+        return processor
+
+    def get_audio_processor(self) -> Callable | None:
+        """Return the audio processor."""
+        if audio is not None:
+            output_kwargs["audio_kwargs"]["padding"] = "max_length"  # Support "max_length" padding only here
+            audio_inputs = self.feature_extractor(audio, **output_kwargs["audio_kwargs"])
+            audio_inputs["feature_attention_mask"] = audio_inputs.pop(
+                "attention_mask"
+            )  # rename feature_attention_mask to prevent conflicts later on
+            audio_inputs["input_features"] = audio_inputs.pop(
+                "input_features"
+            )  # rename input_features to prevent conflicts later on
+            input_lengths = (audio_inputs["feature_attention_mask"].sum(-1) - 1) // 2 + 1
+            audio_lengths = iter((input_lengths - 2) // 2 + 1)
+        else:
+            audio_inputs = {}
+            audio_lengths = iter([])
+
+        def processor(audio: npt.NDArray) -> dict[str, npt.NDArray]:
+            """Invoke the HF processor and convert to dict."""
+            return self.hf_processor(audio=[audio], return_tensors="np").data
+
+        return processor
+
+    def get_video_processor(self) -> Callable | None:
+        """Return the video processor."""
+
+        if videos is not None:
+            videos = make_batched_videos(videos)
+            videos_inputs = self.video_processor(images=None, videos=videos, **output_kwargs["videos_kwargs"])
+            fps = [fps] * len(videos)
+            videos_inputs["video_second_per_grid"] = [
+                self.video_processor.temporal_patch_size / fps[i] for i in range(len(fps))
+            ]
+            video_grid_thw = iter(videos_inputs["video_grid_thw"])
+            video_second_per_grid = iter(videos_inputs["video_second_per_grid"])
+        else:
+            videos_inputs = {}
+            video_grid_thw = iter([])
+            video_second_per_grid = iter([])
+
+        def processor(video: npt.NDArray) -> dict[str, npt.NDArray]:
+            """Invoke the HF processor and convert to dict."""
+            return self.hf_processor(videos=[video], return_tensors="np").data
+
+        return processor

--- a/python/cornserve/task_executors/eric/models/qwen2_5_omni.py
+++ b/python/cornserve/task_executors/eric/models/qwen2_5_omni.py
@@ -376,23 +376,6 @@ class Qwen2_5OmniEncoder(EricModel):
         audio_config = config.thinker_config.audio_config
         audio_config._attn_implementation_autoset = True
         audio_config._attn_implementation = "flash_attention_2"
-        #
-        # from torch.distributed.tensor.parallel import parallelize_module, ColwiseParallel, RowwiseParallel
-        # if parallel.get_tensor_parallel_group().world_size > 1:
-        #     self.audio_tower = parallelize_module(
-        #         Qwen2_5OmniAudioEncoder(audio_config),
-        #         device_mesh=parallel.get_tensor_parallel_group().device_mesh,
-        #         parallelize_plan={
-        #             "layers.*.self_attn.q": ColwiseParallel(),
-        #             "layers.*.self_attn.k": ColwiseParallel(),
-        #             "layers.*.self_attn.v": ColwiseParallel(),
-        #             "layers.*.self_attn.proj": RowwiseParallel(),
-        #             "layers.*.mlp.gate_proj": RowwiseParallel(),
-        #             "layers.*.mlp.up_proj": RowwiseParallel(),
-        #             "layers.*.mlp.down_proj": RowwiseParallel(),
-        #         },
-        #     )
-        # else:
         self.audio_tower = Qwen2_5OmniAudioEncoder(audio_config)
 
     @property

--- a/python/cornserve/task_executors/eric/models/qwen2_5_vl.py
+++ b/python/cornserve/task_executors/eric/models/qwen2_5_vl.py
@@ -33,19 +33,6 @@ def apply_rotary_pos_emb_vision(t: torch.Tensor, freqs: torch.Tensor) -> torch.T
     return output
 
 
-def all_gather_interleave(local_tensor, hidden_size: int, tp_size: int):
-    """All-gather the input tensor interleavely across model parallel group."""
-    import torch.distributed as dist
-
-    gathered_tensors = [torch.zeros_like(local_tensor) for _ in range(tp_size)]
-    dist.all_gather(gathered_tensors, local_tensor, group=parallel.get_tensor_parallel_group().process_group)
-
-    gathered_tensors_split = [torch.split(tensor, hidden_size // tp_size, -1) for tensor in gathered_tensors]
-    ordered_tensors = [tensor for pair in zip(*gathered_tensors_split) for tensor in pair]
-    result_tensor = torch.cat(ordered_tensors, dim=-1)
-    return result_tensor
-
-
 def cast_overflow_tensors(
     tensors: torch.Tensor,
     offset: float = 1000,
@@ -73,19 +60,12 @@ class Qwen2_5_VisionAttention(nn.Module):
         self.embed_dim = embed_dim
 
         self.qkv = ColumnParallelLinear(input_size=embed_dim, output_size=3 * projection_size)
-        # self.qkv = QKVParallelLinear(
-        #     hidden_size=embed_dim,
-        #     head_size=self.hidden_size_per_attention_head,
-        #     total_num_heads=num_heads,
-        #     total_num_kv_heads=num_heads,
-        #     bias=True)
         self.proj = RowParallelLinear(input_size=projection_size, output_size=embed_dim)
 
     def split_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, ...]:
         # [s, b, 3 * head * head_dim]
         seq_len, bs, _ = qkv.shape
         if self.tp_size > 1:
-            # qkv = all_gather_interleave(qkv, self.embed_dim, self.tp_size)
             qkv = self.tp_group.all_gather(qkv)
 
         # [s, b, 3 * head * head_dim] -> 3 * [s, b, head * head_dim]

--- a/python/cornserve/task_executors/eric/models/qwen2_5_vl.py
+++ b/python/cornserve/task_executors/eric/models/qwen2_5_vl.py
@@ -16,7 +16,7 @@ from flash_attn.layers.rotary import apply_rotary_emb
 from .base import EricModel
 from .layers.norm import RMSNorm
 from .layers.activations import get_act_fn
-from .layers.linear import ColumnParallelLinear, RowParallelLinear, QKVParallelLinear
+from .layers.linear import ColumnParallelLinear, RowParallelLinear
 from cornserve.task_executors.eric.api import Modality
 from cornserve.task_executors.eric.distributed import parallel
 from cornserve.task_executors.eric.router.processor import BaseModalityProcessor

--- a/python/cornserve/task_executors/eric/models/registry.py
+++ b/python/cornserve/task_executors/eric/models/registry.py
@@ -20,6 +20,8 @@ class WeightInfo:
     # List of model weight name prefixes to ignore from the state dict.
     # Generally, you will add short prefixes to `required_prefixes` and
     # explicitly ignore specific longer submodules that we do not use.
+    # Note that these prefixes are *after* prefix stripiing if you have
+    # `strip_prefixes` set to `True`.
     ignored_prefixes: list[str] = field(default_factory=list)
 
     # Whether or not to strip the prefixes from weight names before
@@ -100,6 +102,21 @@ MODEL_REGISTRY: dict[str, RegistryEntry] = {
         modality={
             Modality.IMAGE: ModalityEntry(),
             Modality.VIDEO: ModalityEntry(),
+        },
+    ),
+    "qwen2_5_omni": RegistryEntry(
+        module="qwen2_5_omni",
+        class_name="Qwen2_5OmniEncoder",
+        vit_resolution_type=ViTResolutionType.DYNAMIC,
+        weight=WeightInfo(
+            required_prefixes=["thinker."],
+            ignored_prefixes=["model.", "lm_head."],
+            strip_prefixes=True,
+        ),
+        modality={
+            Modality.IMAGE: ModalityEntry(),
+            Modality.VIDEO: ModalityEntry(),
+            Modality.AUDIO: ModalityEntry(),
         },
     ),
     "llava_onevision": RegistryEntry(

--- a/python/cornserve/task_executors/eric/utils/package.py
+++ b/python/cornserve/task_executors/eric/utils/package.py
@@ -1,0 +1,27 @@
+"""Utilities for handling optional package imports."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class PlaceholderModule:
+    """A placeholder class that replaces optional packages when they are not installed."""
+
+    def __init__(self, name: str, optional_dependency_name: str) -> None:
+        """Instantiate a placeholder module with the package's name."""
+        self.__name = name
+        self.__optional_dependency_name = optional_dependency_name
+
+    def __getattr__(self, name: str) -> Any:
+        """Raise an error when any attribute is accessed."""
+        if name == "__name":
+            return self.__name
+
+        if name == "__optional_dependency_name":
+            return self.__optional_dependency_name
+
+        raise RuntimeError(
+            f"Optional package '{self.__name}' is not installed. Please install "
+            f"optional dependencies with `pip install cornserve[{self.__optional_dependency_name}]`."
+        )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -142,6 +142,7 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
+addopts = "-v"
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -67,6 +67,7 @@ task-dispatcher = [
   "opentelemetry-instrumentation-httpx",
   "opentelemetry-instrumentation-grpc",
 ]
+audio = ["librosa"]
 eric-no-gpu = [
   "fastapi",
   "uvicorn[standard]",
@@ -79,11 +80,12 @@ eric-no-gpu = [
   "pillow",
   "opencv-python-headless",
   "einops",
-  "cornserve[sidecar-api]",
+  "cornserve[sidecar-api,audio]",
   "opentelemetry-instrumentation-fastapi",
   "opentelemetry-instrumentation-threading",
 ]
 eric = ["flash-attn", "xformers", "cornserve[eric-no-gpu]"]
+eric-audio = ["cornserve[eric,audio]"]
 dev-common = [
   "grpcio-tools",
   "pyright!=1.1.401",

--- a/python/tests/task_executors/eric/models/conftest.py
+++ b/python/tests/task_executors/eric/models/conftest.py
@@ -35,6 +35,19 @@ def test_videos() -> list[ModalityData]:
     return [ModalityData(url=url, modality=Modality.VIDEO) for url in TEST_VIDEO_URLS]
 
 
+TEST_AUDIO_URLS = [
+    "https://s3.amazonaws.com/citizen-dj-assets.labs.loc.gov/audio/samplepacks/loc-fma/The-Call-of-the-Polar-Star_fma-115766_001_00-00-01.wav",
+    "https://s3.amazonaws.com/citizen-dj-assets.labs.loc.gov/audio/samplepacks/loc-fma/Frog-In-The-Well_fma-39182_001_00-00-06.wav",
+    "https://s3.amazonaws.com/citizen-dj-assets.labs.loc.gov/audio/samplepacks/loc-fma/Free-To-Use-13_fma-152622_004_00-02-55.wav",
+]
+
+
+@pytest.fixture(scope="session")
+def test_audios() -> list[ModalityData]:
+    """Fixture to provide test audios."""
+    return [ModalityData(url=url, modality=Modality.AUDIO) for url in TEST_AUDIO_URLS]
+
+
 @pytest.fixture(scope="session")
 def dump_tensors() -> Generator[str, None, None]:
     """Fixture to set `CORNSERVE_TEST_DUMP_TENSOR_DIR` environment variable."""

--- a/python/tests/task_executors/eric/models/conftest.py
+++ b/python/tests/task_executors/eric/models/conftest.py
@@ -23,8 +23,8 @@ def test_images() -> list[ModalityData]:
 
 TEST_VIDEO_URLS = [
     "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
-    "https://www.sample-videos.com/video321/mp4/360/big_buck_bunny_360p_2mb.mp4",
     "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
+    "https://www.sample-videos.com/video321/mp4/360/big_buck_bunny_360p_2mb.mp4",
     "https://www.sample-videos.com/video321/mp4/720/big_buck_bunny_720p_2mb.mp4",
 ]
 

--- a/python/tests/task_executors/eric/models/test_qwen2_5_omni.py
+++ b/python/tests/task_executors/eric/models/test_qwen2_5_omni.py
@@ -1,4 +1,4 @@
-"""Tests for the Qwen2.5-Omni model's vision encoder."""
+"""Tests for the Qwen2.5-Omni model's vision and audio encoders."""
 
 import pytest
 import torch

--- a/python/tests/task_executors/eric/utils.py
+++ b/python/tests/task_executors/eric/utils.py
@@ -18,14 +18,18 @@ from cornserve.task_executors.eric.schema import Modality, WorkerBatch
 
 TEST_NUM_GPUS: list[int] = [1, 2, 4, 8]
 
-try:
-    CURR_NUM_GPUS = int(
-        subprocess.check_output(["nvidia-smi", "--query-gpu=count", "--format=csv,noheader,nounits", "-i", "0"])
-        .strip()
-        .decode()
-    )
-except subprocess.CalledProcessError:
-    CURR_NUM_GPUS = 0
+if (visible_devices := os.getenv("CUDA_VISIBLE_DEVICES")) is not None:
+    # If CUDA_VISIBLE_DEVICES is set, use it to determine the number of GPUs
+    CURR_NUM_GPUS = len(visible_devices.split(","))
+else:
+    try:
+        CURR_NUM_GPUS = int(
+            subprocess.check_output(["nvidia-smi", "--query-gpu=count", "--format=csv,noheader,nounits", "-i", "0"])
+            .strip()
+            .decode()
+        )
+    except subprocess.CalledProcessError:
+        CURR_NUM_GPUS = 0
 
 
 TP_SIZES = [tp for tp in [1, 2, 4, 8] if tp <= CURR_NUM_GPUS]

--- a/python/tests/task_executors/eric/utils.py
+++ b/python/tests/task_executors/eric/utils.py
@@ -12,7 +12,7 @@ import pytest
 import torch
 import torch.nn as nn
 
-from cornserve.task_executors.eric.config import ImageDataConfig, ModalityConfig, VideoDataConfig
+from cornserve.task_executors.eric.config import AudioDataConfig, ImageDataConfig, ModalityConfig, VideoDataConfig
 from cornserve.task_executors.eric.router.processor import Processor
 from cornserve.task_executors.eric.schema import Modality, WorkerBatch
 
@@ -64,6 +64,7 @@ class ModalityData:
             num_workers=1,
             image_config=ImageDataConfig(),
             video_config=VideoDataConfig(max_num_frames=32),
+            audio_config=AudioDataConfig(),
         )
 
     @cache

--- a/scripts/build_export_images.sh
+++ b/scripts/build_export_images.sh
@@ -5,14 +5,17 @@
 #     export REGISTRY=see-below-for-local-vs-distributed
 #     bash scripts/build_export_images.sh [service1 service2 ...]
 #
-# If no services are specified, it builds all services found in the docker/ directory except for `dev`.
-#
 # The `REGISTRY` environment variable:
 # - If set to `local`, it builds the images directly within the local k3s containerd.
 # - If set to `none`, it just builds the images with Docker without exporting them to anywhere.
 # - If set to `minikube`, it builds the images with Docker and loads them into Minikube.
 # - If set to a URL (e.g., `localhost:30070`), it builds the images with Docker and pushes them to that registry.
 # More details: https://cornserve.ai/contributor_guide/kubernetes/
+#
+# If `eric-audio` is included in the build list, it will be tagged as `eric:latest` instead of `eric-audio:latest`.
+#
+# If no services are specified, the script builds all services found in the docker/ directory except for `dev`.
+# In this case, `eric.Dockerfile` will be skipped, as `eric-audio.Dockerfile` will be used instead.
 
 set -euo pipefail
 
@@ -63,6 +66,11 @@ else
   while IFS= read -r file; do
     if [[ -f "$file" ]]; then
       service=$(basename "$file" .Dockerfile)
+      # Special case: skip eric.Dockerfile if eric-audio.Dockerfile exists
+      # eric-audio will be tagged as eric:latest instead
+      if [[ "$service" == "eric" ]] && [[ -f "docker/eric-audio.Dockerfile" ]]; then
+        continue
+      fi
       if [[ "$service" != "dev" ]]; then
         BUILD_LIST+=("$service")
       fi
@@ -87,8 +95,14 @@ build_and_export() {
     return
   fi
 
-  IMAGE="${NAMESPACE}/${SERVICE}:latest"
-  PUSH_IMAGE="${REGISTRY}/${NAMESPACE}/${SERVICE}:latest"
+  # Special case for eric-audio: name eric
+  if [[ "${SERVICE}" == "eric-audio" ]]; then
+    IMAGE="${NAMESPACE}/eric:latest"
+    PUSH_IMAGE="${REGISTRY}/${NAMESPACE}/eric:latest"
+  else
+    IMAGE="${NAMESPACE}/${SERVICE}:latest"
+    PUSH_IMAGE="${REGISTRY}/${NAMESPACE}/${SERVICE}:latest"
+  fi
   
   if [[ "${REGISTRY}" == "local" ]]; then
     echo "Building image directly within local k3s containerd..."


### PR DESCRIPTION
Vision (image and video) reuses the ones from Qwen 2.5 VL (#78) and the audio encoder is new.

Notes
- `Modality.AUDIO` is new across our codebase.
- Audio packages have licenses that are not compatible with Apache 2.0, so `audio` is a new optional dependency group. We should **not** ship pre-built docker images with the audio dependency either.
- The docker build script is the same as before, because I added optional audio dependencies in `eric.Dockerfile` as a new stage in the multi-stage build Dockerfile. If you never specify a target, the final stage will be built, which includes audio dependencies (`eric-audio`). This should be convenient for dev purposes. However, when shipping Docker images, we explicitly set the target to `eric` to stop the build at the penultimate stage and skip the audio dependencies.

