### PR TITLE
[UX] Streaming task-executor logs back to cli

### DIFF
--- a/docs/contributor_guide/kubernetes.md
+++ b/docs/contributor_guide/kubernetes.md
@@ -35,7 +35,7 @@ You are developing on a multi-node cluster.
 
 ```bash
 bash kubernetes/registry.sh
-REGISTRY=myregisty.com:5000 bash kubernetes/set_registry.sh  # (1)!
+REGISTRY=myregistry.com:5000 bash kubernetes/set_registry.sh  # (1)!
 ```
 
 1. Modifies `kustomization.yaml` and `k3s/registries.yaml`
@@ -48,13 +48,27 @@ sudo cp kubernetes/k3s/registries.yaml /etc/rancher/k3s/registries.yaml
 sudo systemctl start k3s  # or k3s-agent
 ```
 
-(3) Build and push images to the registry using the `build_export_images.sh` script with the `REGISTRY` environment variable set to the registry address:
+(3) On the node that you want to build the images, you also need to specify insecure registries for docker so that it can push images to it. So, in `/etc/docker/daemon.json`, you should add something like,
+
+```
+{
+    "existing configs...",
+    "insecure-registries": ["myregistry.com:5000"]
+}
+```
+
+Then restart docker by `sudo systemctl restart docker`.
+
+(4) Build and push images to the registry using the `build_export_images.sh` script with the `REGISTRY` environment variable set to the registry address:
 
 ```bash
 REGISTRY=myregistry.com:5000 bash scripts/build_export_images.sh
 ```
 
-(4) Use the `dev` overlay (which specifies `imagePullPolicy: Always`) to deploy Cornserve:
+!!! NOTE
+    Building Eric can consume large amount of memory and may trigger OOMs that freeze the instance. Please set a proper `max_jobs` in `eric.dockerfile`, where having 16 GB memory space for each parallel job is usually safe.
+
+(5) Use the `dev` overlay (which specifies `imagePullPolicy: Always`) to deploy Cornserve:
 
 ```bash
 kubectl apply -k kustomize/cornserve-system/overlays/dev

--- a/python/cornserve/cli.py
+++ b/python/cornserve/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -16,6 +17,7 @@ from rich import box
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
+from rich.status import Status
 from tyro.constructors import PrimitiveConstructorSpec
 
 from cornserve.services.gateway.models import (
@@ -23,6 +25,9 @@ from cornserve.services.gateway.models import (
     AppRegistrationRequest,
     AppRegistrationResponse,
 )
+from cornserve.services.gateway.app.models import AppState
+from cornserve.misc import LogStreamer
+
 
 try:
     GATEWAY_URL = os.environ["CORNSERVE_GATEWAY_URL"]
@@ -111,32 +116,138 @@ class Alias:
 def register(
     path: Annotated[Path, tyro.conf.Positional],
     alias: str | None = None,
+    is_async: bool = False,
 ) -> None:
     """Register an app with the Cornserve gateway.
 
     Args:
         path: Path to the app's source file.
         alias: Optional alias for the app.
+        is_async: If true, exit immediately after submission without waiting.
     """
     request = AppRegistrationRequest(source_code=path.read_text().strip())
-    raw_response = requests.post(
-        f"{GATEWAY_URL}/app/register",
-        json=request.model_dump(),
-        timeout=None,
-    )
-    raw_response.raise_for_status()
-    response = AppRegistrationResponse.model_validate(raw_response.json())
+    try:
+        raw_response = requests.post(
+            f"{GATEWAY_URL}/app/register",
+            json=request.model_dump(),
+            timeout=10,
+        )
+        raw_response.raise_for_status()
+        response = AppRegistrationResponse.model_validate(raw_response.json())
+        app_id = response.app_id
+        task_names = response.task_names
+    except requests.exceptions.RequestException as e:
+        rich.print(Panel(f"Failed to send registration request: {e}", style="red", expand=False))
+        return
+    except Exception as e:
+        rich.print(Panel(f"Failed to initiate registration: {e}", style="red", expand=False))
+        return
 
-    app_id = response.app_id
+    if not app_id:
+        rich.print(Panel("Failed to get app_id from registration response.", style="red", expand=False))
+        return
 
-    Alias().set(app_id, alias or path.stem)
+    current_alias = alias or path.stem
+    Alias().set(app_id, current_alias)
 
-    table = Table(box=box.ROUNDED)
-    table.add_column("App ID")
-    table.add_column("Alias")
-    table.add_row(app_id, alias or path.stem)
-    rich.print(table)
+    # Initial display before polling starts
+    initial_table = Table(box=box.ROUNDED)
+    initial_table.add_column("App ID")
+    initial_table.add_column("Alias")
+    initial_table.add_column("Status")
+    initial_table.add_row(app_id, current_alias, Text(AppState.NOT_READY.value.title(), style="yellow"))
+    rich.print(initial_table)
 
+    if task_names:
+        tasks_table = Table(box=box.ROUNDED, title="Discovered Unit Tasks")
+        tasks_table.add_column("Task Name")
+        for name in task_names:
+            tasks_table.add_row(name)
+        rich.print(tasks_table)
+    
+    if is_async:
+        rich.print(Panel(f"App '{app_id}' with alias '{current_alias}' is submitted for registration.", style="green", expand=False))
+        return
+
+    console = rich.get_console()
+    # Have a spinner while we are waiting
+    status_str = AppState.NOT_READY.value
+    spinner_message = f" Waiting for app '{app_id}' to initialize ... Current status: {status_str.title()}"
+
+    log_streamer: LogStreamer | None = None
+    try:
+        with Status(spinner_message, spinner="dots", console=console) as status:
+            start_time = time.time()
+            streamer_attempted = False
+
+            time.sleep(0.2)
+
+            while status_str == AppState.NOT_READY.value:
+                # Start log streamer after a delay
+                if not streamer_attempted and (time.time() - start_time) > 3 and task_names:
+                    log_streamer = LogStreamer(task_names, console=console)
+                    if log_streamer.k8s_available:
+                        log_streamer.start()
+                    else:
+                        rich.print(
+                            Panel(
+                                Text(
+                                    "Could not connect to Kubernetes cluster. Logs will not be streamed.",
+                                    style="yellow",
+                                ),
+                                title="[bold yellow]Log Streaming[/bold yellow]",
+                                border_style="dim",
+                            )
+                        )
+                    streamer_attempted = True  # Attempt to start only once
+
+                try:
+                    status_response = requests.get(f"{GATEWAY_URL}/app/status/{app_id}", timeout=5)
+                    status_response.raise_for_status()
+                    status_data = status_response.json()
+                    status_str = status_data.get("status", "unknown").lower()
+
+                    current_style = "yellow"
+                    if status_str == AppState.READY.value:
+                        current_style = "green"
+                    elif status_str == AppState.REGISTRATION_FAILED.value:
+                        current_style = "red"
+
+                    spinner_message = f" Registering app '{app_id}'... Current status: {status_str.title()}"
+                    status.update(status=Text(spinner_message, style=current_style))
+
+                    if status_str != AppState.NOT_READY.value:
+                        break
+                    time.sleep(1)
+                except requests.exceptions.Timeout:
+                    spinner_message = f" Polling timeout for app '{app_id}'. Retrying..."
+                    status.update(status=Text(spinner_message, style="orange"))
+                    time.sleep(1)
+                except requests.exceptions.RequestException as e:
+                    status_str = "polling_error"
+                    rich.print(Text(f"Error polling status for '{app_id}': {e}", style="red"))
+                    break
+                except Exception as e:
+                    status_str = "unexpected_error"
+                    rich.print(
+                        Text(f"An unexpected error occurred while polling for '{app_id}': {e}", style="red"),
+                    )
+                    break
+    finally:
+        if log_streamer:
+            log_streamer.stop()
+
+    if status_str == AppState.READY.value:
+        rich.print(Panel(f"App '{app_id}' registered successfully with alias '{current_alias}'.", style="green", expand=False))
+    elif status_str == AppState.REGISTRATION_FAILED.value:
+        Alias().remove(current_alias)
+        rich.print(Panel(f"App '{app_id}' failed to register. Alias '{current_alias}' removed.", style="red", expand=False))
+    elif status_str == "polling_error":
+        rich.print(Panel(f"Could not determine final status for app '{app_id}' due to polling errors. Please check with 'cornserve list'.", style="red", expand=False))
+    elif status_str == "unexpected_error":
+        rich.print(Panel(f"An unexpected error occurred while checking status for '{app_id}'. Please check with 'cornserve list'.", style="red", expand=False))
+    else:
+        rich.print(Panel(f"App '{app_id}' registration ended with an inconclusive status: '{status_str.title()}'. Please check with 'cornserve list'.", style="yellow", expand=False))
 
 @app.command(name="unregister")
 def unregister(
@@ -236,6 +347,45 @@ def invoke(
     for key, value in raw_response.json().items():
         table.add_row(key, value)
     rich.print(table)
+
+
+@app.command(name="check-status")
+def check_status(
+    app_id_or_alias: Annotated[str, tyro.conf.Positional],
+) -> None:
+    """Check the registration status of an application."""
+    if app_id_or_alias.startswith("app-"):
+        app_id = app_id_or_alias
+    else:
+        alias = Alias()
+        app_id = alias.get(app_id_or_alias)
+        if not app_id:
+            rich.print(Panel(f"Alias '{app_id_or_alias}' not found.", style="red", expand=False))
+            return
+
+    try:
+        status_response = requests.get(f"{GATEWAY_URL}/app/status/{app_id}", timeout=5)
+
+        if status_response.status_code == 404:
+            rich.print(f"App '{app_id}' not found.")
+            return
+
+        status_response.raise_for_status()
+        status_data = status_response.json()
+        status_str = status_data.get("status", "unknown").lower()
+
+        status_style = "yellow"
+        if status_str == AppState.READY.value:
+            status_style = "green"
+        elif status_str == AppState.REGISTRATION_FAILED.value:
+            status_style = "red"
+        
+        rich.print(f"Status for app '{app_id}': [{status_style}]{status_str.title()}[/{status_style}]")
+
+    except requests.exceptions.RequestException as e:
+        rich.print(Panel(f"Error checking status for '{app_id}': {e}", style="red", expand=False))
+    except Exception as e:
+        rich.print(Panel(f"Unexpected error while checking '{app_id}': {e}", style="red", expand=False))
 
 
 def main() -> None:

--- a/python/cornserve/cli/__init__.py
+++ b/python/cornserve/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI for Cornserve."""

--- a/python/cornserve/cli/main.py
+++ b/python/cornserve/cli/main.py
@@ -20,7 +20,7 @@ from rich.table import Table
 from rich.text import Text
 from tyro.constructors import PrimitiveConstructorSpec
 
-from cornserve.misc import LogStreamer
+from cornserve.cli.log_streamer import LogStreamer
 from cornserve.services.gateway.app.models import AppState
 from cornserve.services.gateway.models import (
     AppInvocationRequest,

--- a/python/cornserve/cli/main.py
+++ b/python/cornserve/cli/main.py
@@ -153,7 +153,7 @@ def register(
     initial_table = Table(box=box.ROUNDED)
     initial_table.add_column("App ID")
     initial_table.add_column("Alias")
-    initial_table.add_column("Status")
+    initial_table.add_column("Initial Status")
     initial_table.add_row(app_id, current_alias, Text(AppState.NOT_READY.value.title(), style="yellow"))
     rich.print(initial_table)
 

--- a/python/cornserve/frontend.py
+++ b/python/cornserve/frontend.py
@@ -12,7 +12,7 @@ import websocket
 from pydantic import BaseModel
 
 from cornserve.constants import K8S_GATEWAY_SERVICE_HTTP_URL
-from cornserve.task.base import Task, UnitTask, UnitTaskList, discover_unit_tasks
+from cornserve.task.base import Task, UnitTask, UnitTaskList, expand_tasks_into_unit_tasks
 
 
 class TaskRequestVerb(enum.Enum):
@@ -162,7 +162,7 @@ class CornserveClient:
         """
         if not self.is_connected():
             raise ConnectionError("Not connected to the Cornserve gateway.")
-        tasks = discover_unit_tasks([task])
+        tasks = expand_tasks_into_unit_tasks([task])
         return self.deploy_unit_tasks(tasks)
 
     def teardown_unit_tasks(self, tasks: list[UnitTask]) -> TaskResponse:
@@ -194,7 +194,7 @@ class CornserveClient:
         """
         if not self.is_connected():
             raise ConnectionError("Not connected to the Cornserve gateway.")
-        tasks = discover_unit_tasks([task])
+        tasks = expand_tasks_into_unit_tasks([task])
         return self.teardown_unit_tasks(tasks)
 
     def close(self) -> None:

--- a/python/cornserve/misc.py
+++ b/python/cornserve/misc.py
@@ -1,0 +1,201 @@
+"""Miscellaneous utilities for the Cornserve CLI."""
+
+from __future__ import annotations
+
+import random
+import subprocess
+import threading
+import time
+from collections import deque
+from typing import Deque
+
+import rich
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+from kubernetes.config.config_exception import ConfigException
+
+# A list of visually distinct colors from rich.
+DISTINCT_COLORS = [
+    "bright_red",
+    "bright_green",
+    "bright_yellow",
+    "bright_blue",
+    "bright_magenta",
+    "bright_cyan",
+    "red",
+    "green",
+    "yellow",
+    "blue",
+    "magenta",
+    "cyan",
+]
+
+
+class LogStreamer:
+    """Streams logs from Kubernetes pods related to unit tasks."""
+
+    def __init__(self, unit_task_names: list[str], namespace: str = "cornserve", console: Console | None = None):
+        self.unit_task_names = unit_task_names
+        self.namespace = namespace
+        self.console = console or rich.get_console()
+        self.k8s_available = self._check_k8s_access()
+        if not self.k8s_available:
+            return
+
+        self.monitored_pods: set[str] = set()
+        self.pod_colors: dict[str, str] = {}
+        self.stop_event = threading.Event()
+        self.threads: list[threading.Thread] = []
+        self.subprocesses: list[subprocess.Popen] = []
+        self.lock = threading.Lock()
+
+    def _check_k8s_access(self) -> bool:
+        self.console.print("[bold yellow]LogStreamer: Checking Kubernetes access...[/bold yellow]")
+
+        # List of config loading attempts
+        config_loaders = [
+            ("default kube config (for standard k8s and Minikube)", lambda: config.load_kube_config()),
+            ("K3s kube config", lambda: config.load_kube_config(config_file="/etc/rancher/k3s/k3s.yaml")),
+        ]
+
+        for description, loader in config_loaders:
+            try:
+                loader()
+                # If loaded, try to access the API
+                self.console.print(f"[bold green]LogStreamer: {description.capitalize()} loaded successfully.[/bold green]")
+                client.CoreV1Api().get_api_resources()
+                self.console.print(f"[bold green]LogStreamer: Kubernetes access confirmed. Going to stream executor logs ... [/bold green]")
+                return True
+            except (ConfigException, FileNotFoundError):
+                self.console.print(f"[bold yellow]LogStreamer: Could not load {description}. Trying next option...[/bold yellow]")
+                continue
+            except ApiException as e:
+                self.console.print(f"[bold red]LogStreamer: API error with {description}: {e}. Aborting check.[/bold red]")
+                return False
+            except Exception as e:
+                # Catch all other unexpected errors during loading or API call.
+                self.console.print(
+                    f"[bold red]LogStreamer: Unexpected error with {description}: {e}. Trying next option...[/bold red]"
+                )
+                continue
+
+        self.console.print("[bold red]LogStreamer: Kubernetes access failed. No log will be streamed.[/bold red]")
+        return False
+
+    def _assign_color(self, pod_name: str):
+        with self.lock:
+            if pod_name in self.pod_colors:
+                return
+
+            used_colors = set(self.pod_colors.values())
+            available_colors = [c for c in DISTINCT_COLORS if c not in used_colors]
+
+            if available_colors:
+                color = random.choice(available_colors)
+            else:
+                # All distinct colors are used, start reusing them
+                color = random.choice(DISTINCT_COLORS)
+            self.pod_colors[pod_name] = color
+
+    def _pod_discovery_worker(self):
+        api = client.CoreV1Api()
+        while not self.stop_event.is_set():
+            try:
+                pods = api.list_namespaced_pod(self.namespace, timeout_seconds=5)
+                for pod in pods.items:
+                    pod_name = pod.metadata.name
+                    if pod_name in self.monitored_pods:
+                        continue
+
+                    for task_name in self.unit_task_names:
+                        # Pod name convention: te-<unit_task_name>-...
+                        if pod_name.startswith(f"te-{task_name}"):
+                            with self.lock:
+                                if pod_name in self.monitored_pods:
+                                    continue
+                                self.monitored_pods.add(pod_name)
+
+                            self._assign_color(pod_name)
+
+                            log_thread = threading.Thread(target=self._log_streaming_worker, args=(pod_name,))
+                            self.threads.append(log_thread)
+                            log_thread.start()
+                            break  # Move to next pod
+            except ApiException as e:
+                error_message = Text(f"Error discovering pods: {e.reason}", style="bold red")
+                self.console.print(error_message)
+                time.sleep(5)  # Wait before retrying on API error
+            except Exception:
+                # Catch other potential exceptions from k8s client
+                time.sleep(5)
+
+            time.sleep(2)  # Poll every 2 seconds for new pods
+
+    def _log_streaming_worker(self, pod_name: str):
+        try:
+            # Wait until pod is running
+            api = client.CoreV1Api()
+            while not self.stop_event.is_set():
+                pod_status = api.read_namespaced_pod_status(pod_name, self.namespace).status.phase
+                if pod_status == "Running":
+                    break
+                if pod_status in ["Succeeded", "Failed", "Unknown"]:
+                    self.console.print(
+                        Text(f"Pod {pod_name} is in state {pod_status}, not streaming logs.", style="yellow")
+                    )
+                    return
+                time.sleep(1)
+
+            proc = subprocess.Popen(
+                ["kubectl", "logs", "-f", "--tail=5", "-n", self.namespace, pod_name],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,  # Redirect stderr to stdout
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            self.subprocesses.append(proc)
+
+            for line in iter(proc.stdout.readline, ""):
+                if self.stop_event.is_set():
+                    break
+                with self.lock:
+                    color = self.pod_colors.get(pod_name, "white")
+                    log_text = f"{pod_name: <40} | {line.strip()}"
+                    log_message = Text(log_text, style=color)
+                self.console.print(log_message)
+
+            proc.stdout.close()
+            return_code = proc.wait()
+            if return_code != 0 and not self.stop_event.is_set():
+                self.console.print(Text(f"Pod {pod_name} exited with code {return_code}.", style="yellow"))
+
+        except Exception as e:
+            self.console.print(Text(f"Error streaming logs for {pod_name}: {e}", style="red"))
+
+    def start(self):
+        if not self.k8s_available:
+            return
+
+        discovery_thread = threading.Thread(target=self._pod_discovery_worker)
+        self.threads.append(discovery_thread)
+        discovery_thread.start()
+
+    def stop(self):
+        if not self.k8s_available:
+            return
+
+        self.stop_event.set()
+        for proc in self.subprocesses:
+            proc.terminate()
+        for thread in self.threads:
+            thread.join(timeout=2)
+        for proc in self.subprocesses:
+            try:
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                proc.kill() 

--- a/python/cornserve/services/gateway/app/manager.py
+++ b/python/cornserve/services/gateway/app/manager.py
@@ -183,6 +183,12 @@ class AppManager:
             async with self.app_lock:  # Lock to safely read self.apps
                 app_def = self.apps.get(app_id)
 
+            if not app_def:
+                logger.error("App definition for app_id '%s' not found during task deployment.", app_id)
+                async with self.app_lock:
+                    self.app_states[app_id] = AppState.REGISTRATION_FAILED
+                return
+
             # Retrieve tasks from the AppDefinition
             tasks_to_deploy = app_def.tasks
 

--- a/python/cornserve/services/gateway/app/manager.py
+++ b/python/cornserve/services/gateway/app/manager.py
@@ -181,13 +181,7 @@ class AppManager:
         try:
             # Retrieve app definition
             async with self.app_lock:  # Lock to safely read self.apps
-                app_def = self.apps.get(app_id)
-
-            if not app_def:
-                logger.error("App definition for app_id '%s' not found during task deployment.", app_id)
-                async with self.app_lock:
-                    self.app_states[app_id] = AppState.REGISTRATION_FAILED
-                return
+                app_def = self.apps[app_id]
 
             # Retrieve tasks from the AppDefinition
             tasks_to_deploy = app_def.tasks

--- a/python/cornserve/services/gateway/app/models.py
+++ b/python/cornserve/services/gateway/app/models.py
@@ -6,8 +6,10 @@ import enum
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from types import ModuleType
+from typing import List
 
 from cornserve.app.base import AppConfig, AppRequest, AppResponse
+from cornserve.task.base import UnitTask
 
 
 class AppState(enum.StrEnum):
@@ -15,6 +17,7 @@ class AppState(enum.StrEnum):
 
     NOT_READY = "not ready"
     READY = "ready"
+    REGISTRATION_FAILED = "registration failed"
 
 
 @dataclass
@@ -43,9 +46,11 @@ class AppDefinition:
         module: The module that contains the app's code.
         source_code: The Python source code of the app.
         classes: The classes that define the app's schema and logic.
+        tasks: The unit tasks discovered in the app's config.
     """
 
     app_id: str
     module: ModuleType
     source_code: str
     classes: AppClasses
+    tasks: List[UnitTask]

--- a/python/cornserve/services/gateway/app/models.py
+++ b/python/cornserve/services/gateway/app/models.py
@@ -6,7 +6,6 @@ import enum
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from types import ModuleType
-from typing import List
 
 from cornserve.app.base import AppConfig, AppRequest, AppResponse
 from cornserve.task.base import UnitTask
@@ -53,4 +52,4 @@ class AppDefinition:
     module: ModuleType
     source_code: str
     classes: AppClasses
-    tasks: List[UnitTask]
+    tasks: list[UnitTask]

--- a/python/cornserve/services/gateway/models.py
+++ b/python/cornserve/services/gateway/models.py
@@ -22,9 +22,11 @@ class AppRegistrationResponse(BaseModel):
 
     Attributes:
         app_id: The unique identifier for the registered application.
+        task_names: The names of the unit tasks discovered in the application.
     """
 
     app_id: str
+    task_names: list[str]
 
 
 class AppInvocationRequest(BaseModel):

--- a/python/cornserve/services/gateway/router.py
+++ b/python/cornserve/services/gateway/router.py
@@ -18,7 +18,6 @@ from pydantic import ValidationError
 from cornserve.constants import K8S_RESOURCE_MANAGER_GRPC_URL
 from cornserve.logging import get_logger
 from cornserve.services.gateway.app.manager import AppManager
-from cornserve.services.gateway.app.models import AppState
 from cornserve.services.gateway.models import (
     AppInvocationRequest,
     AppRegistrationRequest,

--- a/python/cornserve/services/gateway/router.py
+++ b/python/cornserve/services/gateway/router.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 from cornserve.constants import K8S_RESOURCE_MANAGER_GRPC_URL
 from cornserve.logging import get_logger
 from cornserve.services.gateway.app.manager import AppManager
+from cornserve.services.gateway.app.models import AppState
 from cornserve.services.gateway.models import (
     AppInvocationRequest,
     AppRegistrationRequest,
@@ -38,10 +39,10 @@ async def register_app(request: AppRegistrationRequest, raw_request: Request):
     app_manager: AppManager = raw_request.app.state.app_manager
 
     try:
-        app_id = await app_manager.register_app(request.source_code)
-        return AppRegistrationResponse(app_id=app_id)
+        app_id, task_names = await app_manager.register_app(request.source_code)
+        return AppRegistrationResponse(app_id=app_id, task_names=task_names)
     except ValueError as e:
-        logger.info("Error while registering app: %s", e)
+        logger.info("Error while initiating app registration: %s", e)
         return Response(status_code=status.HTTP_400_BAD_REQUEST, content=str(e))
     except Exception as e:
         logger.exception("Unexpected error while registering app")
@@ -107,6 +108,27 @@ async def list_apps(raw_request: Request):
         return await app_manager.list_apps()
     except Exception as e:
         logger.exception("Unexpected error while listing apps")
+        return Response(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content=str(e),
+        )
+
+
+@router.get("/app/status/{app_id}")
+async def get_app_status(app_id: str, raw_request: Request):
+    """Get the registration status of an application."""
+    app_manager: AppManager = raw_request.app.state.app_manager
+    span = trace.get_current_span()
+    span.set_attribute("gateway.get_app_status.app_id", app_id)
+
+    try:
+        app_state = await app_manager.get_app_status(app_id)
+        if app_state is None:
+            return Response(status_code=status.HTTP_404_NOT_FOUND, content=f"App ID '{app_id}' not found")
+        # Return the app_id and the string value of the AppState enum
+        return {"app_id": app_id, "status": app_state.value}
+    except Exception as e:
+        logger.exception("Unexpected error while getting app status for %s", app_id)
         return Response(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content=str(e),

--- a/python/cornserve/task/base.py
+++ b/python/cornserve/task/base.py
@@ -144,8 +144,8 @@ class Task(BaseModel, ABC, Generic[InputT, OutputT]):
             return self.invoke(task_input)
 
 
-def discover_unit_tasks(tasks: Iterable[Task]) -> list[UnitTask]:
-    """Discover unit tasks from an iterable of tasks.
+def expand_tasks_into_unit_tasks(tasks: Iterable[Task]) -> list[UnitTask]:
+    """Expand an iterable of tasks into a list of unit tasks.
 
     A task may itself be a unit task, or a composite task that contains unit tasks
     as subtasks inside it.
@@ -158,7 +158,7 @@ def discover_unit_tasks(tasks: Iterable[Task]) -> list[UnitTask]:
         if isinstance(task, UnitTask):
             unit_tasks.append(task)
         else:
-            unit_tasks.extend(discover_unit_tasks(getattr(task, attr) for attr in task.subtask_attr_names))
+            unit_tasks.extend(expand_tasks_into_unit_tasks(getattr(task, attr) for attr in task.subtask_attr_names))
 
     return unit_tasks
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "rich",
   "requests",
   "tyro",
+  "kubernetes",
   "kubernetes_asyncio",
   "httpx",
   "pydantic>=2.11",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.scripts]
-cornserve = "cornserve.cli:main"
+cornserve = "cornserve.cli.main:main"
 
 [project.optional-dependencies]
 sidecar-api = [

--- a/scripts/build_export_images.sh
+++ b/scripts/build_export_images.sh
@@ -33,7 +33,7 @@ fi
 # Get the user to type their password if they want local k3s containerd export
 if [[ "${REGISTRY}" == "local" ]]; then
   # Ensure k3s is installed and list existing images
-  echo "Building iamge directly within local k3s containerd"
+  echo "Building image directly within local k3s containerd"
   k3s_bin="$(which k3s)"
   sudo "${k3s_bin}" ctr images ls | grep -i "${NAMESPACE}" || true
 


### PR DESCRIPTION
This PR implements the log streaming functionality proposed in #73, major changes are
- adding the LogStreamer class, which detects available k8s configs (k8s, k3s, and minikube), checks k8s access, and pulls the logs of task-executors with a given list of unit_task names
- changing the gateway's `register_app` logic to be async. So the gateway returns the `app_id` and unit task names once the app is validated. Then the cli will automatically pulls the status of the app registration and initialization by using the app_id.
- now cli's register command can also specify is_async directly, in case the user want to pull the app status manually.

Minor changes includes

- put cli and log_streamer code under the same `python/cornserve/cli/` directory
- rename `discover_unit_tasks()` as  `expand_tasks_into_unit_tasks()`
- add more docs about multi-node setup and typo fixes