### PR TITLE
[Task] Support disaggregated LLMTask with prefill tasks and decode tasks

### DIFF
--- a/docker/vllm.Dockerfile
+++ b/docker/vllm.Dockerfile
@@ -45,9 +45,6 @@ ENV VLLM_USE_V1=1
 ENV HF_HOME="/root/.cache/huggingface"
 ENTRYPOINT ["vllm", "serve"]
 
-ENV UCX_TLS=cuda,rc,ib
-ENV UCX_LOG_LEVEL=debug
-
 # Default final stage with audio support
 FROM vllm AS vllm-audio
 RUN uv pip install -e .[audio] && uv cache clean

--- a/docker/vllm.Dockerfile
+++ b/docker/vllm.Dockerfile
@@ -5,6 +5,11 @@ RUN apt-get update -y \
         git \
         curl \
         wget \
+        infiniband-diags \
+        ibverbs-utils \
+        rdma-core \
+        ibverbs-providers \
+        librdmacm-dev \
         build-essential \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && apt-get clean \
@@ -29,7 +34,7 @@ RUN uv pip install -r requirements/common.txt \
 # Set environment variables
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.0.1.dev
 ENV VLLM_USE_PRECOMPILED=1
-ENV VLLM_COMMIT=6b6d4961147220fb80f9cc7dcb74db478f9c9a23
+ENV VLLM_COMMIT=c18b3b8e8bdcebaa150311d2c4911a6428480162
 ENV VLLM_PRECOMPILED_WHEEL_LOCATION=https://wheels.vllm.ai/${VLLM_COMMIT}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
 
 # Intermediate vllm stage without audio
@@ -39,6 +44,9 @@ RUN uv pip install -e . && uv cache clean
 ENV VLLM_USE_V1=1
 ENV HF_HOME="/root/.cache/huggingface"
 ENTRYPOINT ["vllm", "serve"]
+
+ENV UCX_TLS=cuda,rc,ib
+ENV UCX_LOG_LEVEL=debug
 
 # Default final stage with audio support
 FROM vllm AS vllm-audio

--- a/python/cornserve/services/sidecar/launch.py
+++ b/python/cornserve/services/sidecar/launch.py
@@ -112,7 +112,7 @@ class SidecarLaunchInfo:
     def get_container_volumes() -> list[tuple[str, str, str]]:
         """Get the container volumes for the sidecar."""
         return [
-            ("shm-volume", constants.VOLUME_SHM, "/dev/shm"),
+            ("shm", constants.VOLUME_SHM, "/dev/shm"),
             ("infiniband-class", "/sys/class/infiniband", "/sys/class/infiniband"),
             ("infiniband-dev", "/dev/infiniband", "/dev/infiniband"),
         ]

--- a/python/cornserve/services/task_manager/manager.py
+++ b/python/cornserve/services/task_manager/manager.py
@@ -263,7 +263,7 @@ class TaskManager:
         pod_name = f"te-{executor_id}"
         service_name = to_strict_k8s_name(f"te-{executor_id}")
         additional_service_ports = self.descriptor.get_service_ports(gpus)
-        additional_envs = self.descriptor.get_container_envs(service_name, gpus)
+        additional_envs = self.descriptor.get_container_envs(gpus)
         port = 8000
 
         # Task-specific environment variables for downward API

--- a/python/cornserve/sidecar/api.py
+++ b/python/cornserve/sidecar/api.py
@@ -42,7 +42,7 @@ ThreadingInstrumentor().instrument()
 class Sidecar:
     """The sidecar client to send or receive data to/from other sidecars."""
 
-    supported_classes = [str, bytes, int, float, bool, torch.Tensor]
+    supported_classes = [str, bytes, int, float, bool, torch.Tensor, dict]
 
     def __init__(
         self,
@@ -207,6 +207,7 @@ class Sidecar:
         if isinstance(obj, SharedTensorHandle):
             cbuf = (ctypes.c_byte * obj.numel * self.dtype.itemsize).from_address(self.base_ptr + obj.offset)
             tensor = torch.frombuffer(cbuf, dtype=self.dtype, count=obj.numel)
+            logger.info("Received shard %d of chunk %d in req %s successfully", self.shard_rank, chunk_id, id)
             return tensor.view(self.config.get_recv_tensor_shape())
         else:
             return obj
@@ -234,6 +235,7 @@ class Sidecar:
         if isinstance(obj, SharedTensorHandle):
             cbuf = (ctypes.c_byte * obj.numel * self.dtype.itemsize).from_address(self.base_ptr + obj.offset)
             tensor = torch.frombuffer(cbuf, dtype=self.dtype, count=obj.numel)
+            logger.info("Sync read shard %d of chunk %d in req %s successfully", self.shard_rank, chunk_id, id)
             return tensor.view(self.config.get_recv_tensor_shape())
         else:
             return obj

--- a/python/cornserve/task/builtins/llm.py
+++ b/python/cornserve/task/builtins/llm.py
@@ -21,11 +21,12 @@ All tasks are OpenAI compatible and output is always streamed.
 
 from __future__ import annotations
 
+import uuid
 from collections import defaultdict
 from typing import Literal, TypeAlias
 
 from openai.types.chat import ChatCompletionChunk
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from cornserve.task.base import Stream, Task, TaskInput, TaskOutput, UnitTask
 from cornserve.task.builtins.encoder import EncoderInput, EncoderOutput, EncoderTask, Modality
@@ -105,6 +106,7 @@ class OpenAIChatCompletionRequest(TaskInput):
     stream_options: StreamOptions | None = None
     temperature: float | None = None
     top_p: float | None = None
+    request_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
 
     cornserve_embeddings: list[DataForward[Tensor]] = []
 
@@ -233,3 +235,162 @@ class MLLMTask(Task[OpenAIChatCompletionRequest, Stream[OpenAIChatCompletionChun
 
         # Invoke the LLM task.
         return self.llm.invoke(task_input)
+
+
+class PrefillChatCompletionResponse(TaskOutput):
+    """Output model for Prefill vLLM Chat Completion tasks."""
+
+    kv_transfer_params: DataForward[dict]
+
+
+class PrefillLLMUnitTask(UnitTask[OpenAIChatCompletionRequest, PrefillChatCompletionResponse]):
+    """A task that invokes a vLLM to perform prefill."""
+
+    model_id: str
+    receive_embeddings: bool = True
+
+    def make_name(self) -> str:
+        """Create a concise string representation of the task."""
+        return f"prefill-{self.model_id.split('/')[-1].lower()}"
+
+    def make_record_output(self, task_input: OpenAIChatCompletionRequest) -> PrefillChatCompletionResponse:
+        """Create a mock task output object for invocation recording."""
+        return PrefillChatCompletionResponse(kv_transfer_params=DataForward[dict]())
+
+    def validate_input(self, task_input: OpenAIChatCompletionRequest) -> None:
+        """Validate the task input."""
+        if task_input.model != self.model_id:
+            raise ValueError(
+                f"Model ID in task input ({task_input.model}) does not match the task model ID ({self.model_id})."
+            )
+
+
+class DecodeChatCompletionRequest(TaskInput):
+    """Input model for decode vLLM Chat Completion tasks."""
+
+    messages: list[ChatCompletionMessageParam]
+    model: str
+    frequency_penalty: float | None = 0.0
+    max_completion_tokens: int | None = None
+    presence_penalty: float | None = 0.0
+    seed: int | None = None
+    stream_options: StreamOptions | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    # the request_id must be the same as the one used in the prefill request
+    request_id: str
+
+    cornserve_embeddings: list[DataForward[Tensor]] = []
+    cornserve_kv_transfer_params: DataForward[dict]
+
+
+class DecodeLLMUnitTask(UnitTask[DecodeChatCompletionRequest, Stream[OpenAIChatCompletionChunk]]):
+    """A task that invokes a vLLM decoder and returns a stream of chat completion chunks."""
+
+    model_id: str
+    receive_embeddings: bool = True
+
+    def make_name(self) -> str:
+        """Create a concise string representation of the task."""
+        return f"decode-{self.model_id.split('/')[-1].lower()}"
+
+    def make_record_output(self, task_input: DecodeChatCompletionRequest) -> Stream[OpenAIChatCompletionChunk]:
+        """Create a mock task output object for invocation recording."""
+        return Stream[OpenAIChatCompletionChunk]()
+
+    def validate_input(self, task_input: DecodeChatCompletionRequest) -> None:
+        """Validate the task input."""
+        if task_input.model != self.model_id:
+            raise ValueError(
+                f"Model ID in task input ({task_input.model}) does not match the task model ID ({self.model_id})."
+            )
+        if not task_input.cornserve_kv_transfer_params:
+            raise ValueError("KV transfer parameters must be specified in the task input.")
+
+
+class DisaggregatedMLLMTask(Task[OpenAIChatCompletionRequest, Stream[OpenAIChatCompletionChunk]]):
+    """A task that invokes a Multimodal LLM, with disaggregated prefill and decode in LLM.
+
+    Attributes:
+        model_id: The ID of the model to use for the task.
+        modalities: List of input modalities other than text.
+        adapter_model_ids: Some models support multiple adapters and allow the
+            base model to be shared (e.g., Gemma 3). This list specifies model IDs
+            from which to load adapters. Base model weights are loaded from `model_id`.
+        encoder_fission: If True, the task will use separate encoder tasks for computing
+            multimodal embeddings. If False, it will use the LLM server to compute them.
+    """
+
+    model_id: str
+    modalities: list[Modality] = []
+    adapter_model_ids: list[str] = []
+    encoder_fission: bool = True
+
+    def post_init(self) -> None:
+        """Initialize subtasks."""
+        if self.encoder_fission:
+            self.encoders = {
+                modality: EncoderTask(
+                    model_id=self.model_id,
+                    adapter_model_ids=self.adapter_model_ids,
+                    modality=modality,
+                )
+                for modality in self.modalities
+            }
+        self.prefill = PrefillLLMUnitTask(model_id=self.model_id, receive_embeddings=self.encoder_fission)
+        self.decode = DecodeLLMUnitTask(model_id=self.model_id, receive_embeddings=self.encoder_fission)
+
+    def invoke(self, task_input: OpenAIChatCompletionRequest) -> Stream[OpenAIChatCompletionChunk]:
+        """Invoke the task."""
+        if self.encoder_fission:
+            encoder_input_urls: dict[Modality, list[str]] = defaultdict(list)
+            multimodal_contents = extract_multimodal_content(task_input.messages)
+            for multimodal_content in multimodal_contents:
+                modality = Modality(multimodal_content.type.split("_")[0])
+                data_url: URL = getattr(multimodal_content, multimodal_content.type)
+                encoder_input_urls[modality].append(data_url.url)
+
+            # Check if modalities not specified in the task are present in the input.
+            if diff := set(encoder_input_urls.keys()) - set(self.modalities):
+                raise ValueError(
+                    "The following modalities in the input are not specified in the task: "
+                    f"{[mod.value for mod in diff]}",
+                )
+
+            # Invoke the encoder tasks for each modality
+            encoder_outputs: dict[Modality, EncoderOutput] = {}
+            for modality, encoder_task in self.encoders.items():
+                if modality not in encoder_input_urls:
+                    continue
+                encoder_input = EncoderInput(model_id=task_input.model, data_urls=encoder_input_urls[modality])
+                encoder_output = encoder_task.invoke(encoder_input)
+                encoder_outputs[modality] = encoder_output
+
+            # Retain the order of multimodal data in the task input
+            embeddings: list[DataForward[Tensor]] = []
+            for multimodal_content in multimodal_contents:
+                modality = Modality(multimodal_content.type.split("_")[0])
+                embeddings.append(encoder_outputs[modality].embeddings.pop(0))
+
+            # To be consumed by the LLM task.
+            task_input.cornserve_embeddings = embeddings
+
+        prefill_output = self.prefill.invoke(task_input)
+        decode_input = DecodeChatCompletionRequest(
+            messages=task_input.messages,
+            model=task_input.model,
+            frequency_penalty=task_input.frequency_penalty,
+            max_completion_tokens=task_input.max_completion_tokens,
+            presence_penalty=task_input.presence_penalty,
+            seed=task_input.seed,
+            stream_options=task_input.stream_options,
+            temperature=task_input.temperature,
+            top_p=task_input.top_p,
+            request_id=task_input.request_id,
+            cornserve_kv_transfer_params=prefill_output.kv_transfer_params,
+            # enable below bc sometimes the decode instance also needs the image embeddings
+            cornserve_embeddings=task_input.cornserve_embeddings,
+        )
+
+        # Invoke the LLM task.
+        return self.decode.invoke(decode_input)

--- a/python/cornserve/task/builtins/llm.py
+++ b/python/cornserve/task/builtins/llm.py
@@ -377,19 +377,11 @@ class DisaggregatedMLLMTask(Task[OpenAIChatCompletionRequest, Stream[OpenAIChatC
 
         prefill_output = self.prefill.invoke(task_input)
         decode_input = DecodeChatCompletionRequest(
-            messages=task_input.messages,
-            model=task_input.model,
-            frequency_penalty=task_input.frequency_penalty,
-            max_completion_tokens=task_input.max_completion_tokens,
-            presence_penalty=task_input.presence_penalty,
-            seed=task_input.seed,
-            stream_options=task_input.stream_options,
-            temperature=task_input.temperature,
-            top_p=task_input.top_p,
-            request_id=task_input.request_id,
+            # ideally we want to exclude and remove `cornserve_embeddings`
+            # but sometimes the decode instance needs the image embeddings
+            # due to a potential bug in vLLM
+            **task_input.model_dump(),
             cornserve_kv_transfer_params=prefill_output.kv_transfer_params,
-            # enable below bc sometimes the decode instance also needs the image embeddings
-            cornserve_embeddings=task_input.cornserve_embeddings,
         )
 
         # Invoke the LLM task.

--- a/python/cornserve/task/forward.py
+++ b/python/cornserve/task/forward.py
@@ -22,6 +22,7 @@ class ForwardableType(enum.StrEnum):
     FLOAT = "float"
     BOOL = "bool"
     TENSOR = "Tensor"
+    DICT = "dict"
 
 
 DataT = TypeVar("DataT")

--- a/python/cornserve/task_executors/descriptor/base.py
+++ b/python/cornserve/task_executors/descriptor/base.py
@@ -49,6 +49,16 @@ class TaskExecutionDescriptor(BaseModel, ABC, Generic[TaskT, InputT, OutputT]):
             ("shm", constants.VOLUME_SHM, "/dev/shm"),
         ]
 
+    def get_service_ports(self, gpus: list[GPU]) -> list[tuple[str, int]]:
+        """Get the additional service ports for the task executor."""
+        return []
+
+    def get_container_envs(self, gpus: list[GPU]) -> list[tuple[str, str]]:
+        """Get the additional environment variables for the task executor."""
+        return [
+            ("CUDA_VISIBLE_DEVICES", ",".join(str(gpu.local_rank) for gpu in gpus)),
+        ]
+
     @abstractmethod
     def get_api_url(self, base: str) -> str:
         """Get the task executor's base URL for API calls.

--- a/python/cornserve/task_executors/descriptor/base.py
+++ b/python/cornserve/task_executors/descriptor/base.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
 import httpx
+import kubernetes_asyncio.client as kclient
 from pydantic import BaseModel
 
 from cornserve import constants
@@ -58,6 +59,11 @@ class TaskExecutionDescriptor(BaseModel, ABC, Generic[TaskT, InputT, OutputT]):
         return [
             ("CUDA_VISIBLE_DEVICES", ",".join(str(gpu.local_rank) for gpu in gpus)),
         ]
+
+    def get_kubernetes_envs(self, gpus: list[GPU]) -> list[kclient.V1EnvVar]:
+        """Get the kubernetes environment variables for the task executor."""
+        envs = [kclient.V1EnvVar(name=n, value=v) for n, v in self.get_container_envs(gpus)]
+        return envs
 
     @abstractmethod
     def get_api_url(self, base: str) -> str:

--- a/python/cornserve/task_executors/descriptor/builtins/llm.py
+++ b/python/cornserve/task_executors/descriptor/builtins/llm.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, ClassVar
 
 import httpx
 
@@ -13,9 +13,13 @@ from cornserve.services.resource_manager.resource import GPU
 from cornserve.task.base import Stream
 from cornserve.task.builtins.llm import (
     URL,
+    DecodeChatCompletionRequest,
+    DecodeLLMUnitTask,
     LLMUnitTask,
     OpenAIChatCompletionChunk,
     OpenAIChatCompletionRequest,
+    PrefillChatCompletionResponse,
+    PrefillLLMUnitTask,
     extract_multimodal_content,
 )
 from cornserve.task_executors.descriptor.base import TaskExecutionDescriptor
@@ -147,3 +151,254 @@ class VLLMDescriptor(
 
 
 DESCRIPTOR_REGISTRY.register(LLMUnitTask, VLLMDescriptor, default=True)
+
+
+class PrefillVLLMDescriptor(
+    TaskExecutionDescriptor[
+        PrefillLLMUnitTask,
+        OpenAIChatCompletionRequest,
+        PrefillChatCompletionResponse,
+    ]
+):
+    """Task execution descriptor using vLLM in prefill mode."""
+
+    NIXL_BASE_PORT: ClassVar[int] = 5565
+
+    def create_executor_name(self) -> str:
+        """Create a name for the task executor."""
+        return "-".join(["prefill", self.task.model_id.split("/")[-1]]).lower()
+
+    def get_container_image(self) -> str:
+        """Get the container image name for the task executor."""
+        return constants.CONTAINER_IMAGE_VLLM
+
+    def get_service_ports(self, gpus: list[GPU]) -> list[tuple[str, int]]:
+        """Get the additional service ports for the task executor."""
+        return [
+            ("nixl", self.NIXL_BASE_PORT + gpus[0].global_rank),
+            ("test", 5000),
+        ]
+
+    def get_container_envs(self, gpus: list[GPU]) -> list[tuple[str, str]]:
+        """Get the additional environment variables for the task executor."""
+        return [
+            ("UCX_TLS", "cuda,rc,ib,tcp"),
+            # ("UCX_TLS", "cuda,rc,ib"),
+            ("UCX_NET_DEVICES", "mlx5_0:1"),
+            ("UCX_LOG_LEVEL", "debug"),
+            ("CUDA_VISIBLE_DEVICES", ",".join(str(gpu.local_rank) for gpu in gpus)),
+            ("VLLM_LOGGING_LEVEL", "DEBUG"),
+            ("VLLM_NIXL_SIDE_CHANNEL_PORT", str(self.NIXL_BASE_PORT + gpus[0].global_rank)),
+        ]
+
+    def get_container_args(self, gpus: list[GPU], port: int) -> list[str]:
+        """Get the container command for the task executor."""
+        args = [
+            self.task.model_id,
+            "--tensor-parallel-size",
+            str(len(gpus)),
+            "--port",
+            str(port),
+            "--enforce-eager",
+            "--kv-transfer-config",
+            '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}',
+            # need to forward KV transfer parameters to a decode instance
+            "--cornserve-sidecar-ranks",
+            *[str(gpu.global_rank) for gpu in gpus],
+        ]
+        return args
+
+    def get_container_volumes(self) -> list[tuple[str, str, str]]:
+        """Get the container volumes for the task manager.
+
+        Returns:
+            A list of tuples: name, host path, container path.
+        """
+        return [
+            ("infiniband-class", "/sys/class/infiniband", "/sys/class/infiniband"),
+            ("infiniband-dev", "/dev/infiniband", "/dev/infiniband"),
+            ("hf-cache", constants.VOLUME_HF_CACHE, "/root/.cache/huggingface"),
+            ("shm", constants.VOLUME_SHM, "/dev/shm"),
+        ]
+
+    def get_api_url(self, base: str) -> str:
+        """Get the task executor's base URL for API calls."""
+        return f"{base}/v1/chat/completions"
+
+    def to_request(
+        self,
+        task_input: OpenAIChatCompletionRequest,
+        task_output: PrefillChatCompletionResponse,
+    ) -> dict[str, Any]:
+        """Convert TaskInput to a request object for the task executor."""
+        # If `cornserve_embeddings` is empty, the request will be sent to vLLM as is.
+        # If not, we inspect the request's messages and replace multimodal data URLs
+        # with Cornserve sidecar-compatible URIs (using data IDs in `DataForward`).
+        # The expectation is that the number of multimodal data is the same as the
+        # length of `cornserve_embeddings`.
+        if self.task.receive_embeddings:
+            multimodal_data = extract_multimodal_content(task_input.messages)
+            if len(multimodal_data) != len(task_input.cornserve_embeddings):
+                logger.error(
+                    "The number of multimodal data in messages (%d) does not match "
+                    "the number of embeddings provided (%d). Multimodal data: %s, Embeddings: %s",
+                    len(multimodal_data),
+                    len(task_input.cornserve_embeddings),
+                    multimodal_data,
+                    task_input.cornserve_embeddings,
+                )
+                raise ValueError(
+                    "The number of multimodal data in messages does not match the number of embeddings provided."
+                )
+            for multimodal_content, forward in zip(multimodal_data, task_input.cornserve_embeddings, strict=True):
+                modality = multimodal_content.type.split("_")[0]  # e.g., "audio", "image", "video"
+                data_url: URL = getattr(multimodal_content, multimodal_content.type)
+                data_url.url = f"data:{modality}/uuid;data_id={forward.id};url={data_url.url},"
+
+        # force non-streaming
+        request = task_input.model_dump(exclude={"cornserve_embeddings", "stream_options"})
+        # overwrite max_completion_tokens
+        request["max_completion_tokens"] = 1
+        request["kv_transfer_params"] = {
+            "do_remote_decode": True,
+            "do_remote_prefill": False,
+            "remote_engine_id": None,
+            "remote_block_ids": None,
+            "remote_host": None,
+            "remote_port": None,
+        }
+        request["cornserve_kv_transfer_send_params"] = {
+            "id": task_output.kv_transfer_params.id,
+            "receiver_sidecar_ranks": task_output.kv_transfer_params.dst_sidecar_ranks,
+        }
+        return request
+
+    def from_response(
+        self,
+        task_output: PrefillChatCompletionResponse,
+        response: httpx.Response,
+    ) -> PrefillChatCompletionResponse:
+        """Convert the response from the task executor to TaskOutput."""
+        resp = response.json()
+        if "kv_transfer_params" not in resp:
+            raise ValueError("Response does not contain kv_transfer_params.")
+        return PrefillChatCompletionResponse(kv_transfer_params=task_output.kv_transfer_params)
+
+
+DESCRIPTOR_REGISTRY.register(PrefillLLMUnitTask, PrefillVLLMDescriptor, default=True)
+
+
+class DecodeVLLMDescriptor(
+    TaskExecutionDescriptor[DecodeLLMUnitTask, DecodeChatCompletionRequest, Stream[OpenAIChatCompletionChunk]]
+):
+    """Task execution descriptor using vLLM in decode mode."""
+
+    NIXL_BASE_PORT: ClassVar[int] = 5665
+
+    def create_executor_name(self) -> str:
+        """Create a name for the task executor."""
+        return "-".join(["decode", self.task.model_id.split("/")[-1]]).lower()
+
+    def get_container_image(self) -> str:
+        """Get the container image name for the task executor."""
+        return constants.CONTAINER_IMAGE_VLLM
+
+    def get_service_ports(self, gpus: list[GPU]) -> list[tuple[str, int]]:
+        """Get the additional service ports for the task executor."""
+        return [
+            ("nixl", self.NIXL_BASE_PORT + gpus[0].global_rank),
+            ("test", 5000),
+        ]
+
+    def get_container_envs(self, gpus: list[GPU]) -> list[tuple[str, str]]:
+        """Get the additional environment variables for the task executor."""
+        return [
+            ("UCX_TLS", "cuda,rc,ib,tcp"),
+            # ("UCX_TLS", "cuda,rc,ib"),
+            ("UCX_NET_DEVICES", "mlx5_0:1"),
+            # ("UCX_LOG_LEVEL", "debug"),
+            ("CUDA_VISIBLE_DEVICES", ",".join(str(gpu.local_rank) for gpu in gpus)),
+            # ("VLLM_LOGGING_LEVEL", "DEBUG"),
+            ("VLLM_NIXL_SIDE_CHANNEL_PORT", str(self.NIXL_BASE_PORT + gpus[0].global_rank)),
+        ]
+
+    def get_container_args(self, gpus: list[GPU], port: int) -> list[str]:
+        """Get the container command for the task executor."""
+        args = [
+            self.task.model_id,
+            "--tensor-parallel-size",
+            str(len(gpus)),
+            "--port",
+            str(port),
+            "--enforce-eager",
+            "--kv-transfer-config",
+            '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}',
+            # need to receive KV transfer parameters from a decode instance
+            "--cornserve-sidecar-ranks",
+            *[str(gpu.global_rank) for gpu in gpus],
+        ]
+
+        return args
+
+    def get_container_volumes(self) -> list[tuple[str, str, str]]:
+        """Get the container volumes for the task manager.
+
+        Returns:
+            A list of tuples: name, host path, container path.
+        """
+        return [
+            ("infiniband-class", "/sys/class/infiniband", "/sys/class/infiniband"),
+            ("infiniband-dev", "/dev/infiniband", "/dev/infiniband"),
+            ("hf-cache", constants.VOLUME_HF_CACHE, "/root/.cache/huggingface"),
+            ("shm", constants.VOLUME_SHM, "/dev/shm"),
+        ]
+
+    def get_api_url(self, base: str) -> str:
+        """Get the task executor's base URL for API calls."""
+        return f"{base}/v1/chat/completions"
+
+    def to_request(
+        self,
+        task_input: DecodeChatCompletionRequest,
+        task_output: Stream[OpenAIChatCompletionChunk],
+    ) -> dict[str, Any]:
+        """Convert TaskInput to a request object for the task executor."""
+        if self.task.receive_embeddings:
+            multimodal_data = extract_multimodal_content(task_input.messages)
+            if len(multimodal_data) != len(task_input.cornserve_embeddings):
+                logger.error(
+                    "The number of multimodal data in messages (%d) does not match "
+                    "the number of embeddings provided (%d). Multimodal data: %s, Embeddings: %s",
+                    len(multimodal_data),
+                    len(task_input.cornserve_embeddings),
+                    multimodal_data,
+                    task_input.cornserve_embeddings,
+                )
+                raise ValueError(
+                    "The number of multimodal data in messages does not match the number of embeddings provided."
+                )
+            for multimodal_content, forward in zip(multimodal_data, task_input.cornserve_embeddings, strict=True):
+                modality = multimodal_content.type.split("_")[0]  # e.g., "audio", "image", "video"
+                data_url: URL = getattr(multimodal_content, multimodal_content.type)
+                data_url.url = f"data:{modality}/uuid;data_id={forward.id};url={data_url.url},"
+
+        request = task_input.model_dump(exclude={"cornserve_embeddings", "cornserve_kv_transfer_params"})
+        request["cornserve_kv_transfer_recv_params"] = {
+            "id": task_input.cornserve_kv_transfer_params.id,
+        }
+        request["stream"] = True
+        return request
+
+    def from_response(
+        self,
+        task_output: Stream[OpenAIChatCompletionChunk],
+        response: httpx.Response,
+    ) -> Stream[OpenAIChatCompletionChunk]:
+        """Convert the response from the task executor to TaskOutput."""
+        return Stream[OpenAIChatCompletionChunk](
+            async_iterator=parse_stream_to_completion_chunks(response),
+            response=response,
+        )
+
+
+DESCRIPTOR_REGISTRY.register(DecodeLLMUnitTask, DecodeVLLMDescriptor, default=True)

--- a/python/cornserve/task_executors/descriptor/builtins/llm.py
+++ b/python/cornserve/task_executors/descriptor/builtins/llm.py
@@ -176,7 +176,6 @@ class PrefillVLLMDescriptor(
         """Get the additional service ports for the task executor."""
         return [
             ("nixl", self.NIXL_BASE_PORT + gpus[0].global_rank),
-            ("test", 5000),
         ]
 
     def get_container_envs(self, gpus: list[GPU]) -> list[tuple[str, str]]:
@@ -307,7 +306,6 @@ class DecodeVLLMDescriptor(
         """Get the additional service ports for the task executor."""
         return [
             ("nixl", self.NIXL_BASE_PORT + gpus[0].global_rank),
-            ("test", 5000),
         ]
 
     def get_container_envs(self, gpus: list[GPU]) -> list[tuple[str, str]]:


### PR DESCRIPTION
* vLLM is bumped to v0.9.2 with NIXL support
* NIXL requires using RDMA devices within the task executor pods, and it will require additional security contexts. Currently, `privileged=True` is used.
* NIXL/UCX does not work when using shared memory transports in k8s in this PR, so related transports are excluded.
* Supports both `encoder_fission` modes of PD
* Note: Sometimes the decode engine still requires one encoder input even if it's fetching remote prefill kv caches. This behavior appears in the original vLLM v0.9.2 as well and it might be a bug.