### PR TITLE
[CI] Use `uv`

### DIFF
--- a/.github/workflows/python_lint.yaml
+++ b/.github/workflows/python_lint.yaml
@@ -26,14 +26,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: 3.11
-          cache: 'pip'
+          enable-cache: true
+          python-version: "3.11"
+          version: "latest"
       - name: Install library and lint tools
-        run: pip install -U pip && pip install "./python[dev-no-gpu]"
+        run: uv venv --python 3.11 && uv pip install "./python[dev-no-gpu]"
       - name: Generate protobuf files
-        run: bash scripts/generate_pb.sh
+        run: uv run bash scripts/generate_pb.sh
       - name: Check format and lint
-        run: bash python/scripts/lint.sh
+        run: uv run bash python/scripts/lint.sh


### PR DESCRIPTION
Even with full cache hit, Python CI used to take something like 2.5 minutes. Without cache it, more than 13 minutes ([ref](https://github.com/cornserve-ai/cornserve/actions/runs/16666782288)).

With `uv`, with or without cache hit, it takes something like 50 to 55 seconds.