### PR TITLE
[Task] Encoder parallelism for `MLLMTask`

### DIFF
--- a/python/cornserve/services/task_manager/manager.py
+++ b/python/cornserve/services/task_manager/manager.py
@@ -63,6 +63,9 @@ class TaskManager:
         # Load the unit task profile
         self.task_profile = UnitTaskProfileManager(profile_dir=constants.UNIT_TASK_PROFILES_DIR).get_profile(task)
 
+        # Round robin routing
+        self.rr_counter = 0
+
     @classmethod
     async def init(cls, id: str, task: UnitTask, gpus: list[GPU]) -> TaskManager:
         """Initialize the designated task manager.
@@ -244,7 +247,10 @@ class TaskManager:
         """
         logger.info("Routing request %s with routing hint %s", request_id, routing_hint)
 
-        index = hash(request_id) % len(self.executor_deployments)
+        # index = hash(request_id) % len(self.executor_deployments)
+        # Round robin routing
+        index = self.rr_counter % len(self.executor_deployments)
+        self.rr_counter += 1
         deployment = list(self.executor_deployments.values())[index]
 
         route = deployment.url

--- a/python/cornserve/task/builtins/llm.py
+++ b/python/cornserve/task/builtins/llm.py
@@ -161,6 +161,9 @@ class MLLMTask(Task[OpenAIChatCompletionRequest, Stream[OpenAIChatCompletionChun
         modalities: List of input modalities other than text.
         encoder_fission: If True, the task will use separate encoder tasks for computing
             multimodal embeddings. If False, it will use the LLM server to compute them.
+        coalesce_encoder_invocations: If True, the task will coalesce encoder invocations
+            for the same modality into a single invocation. If False, it will invoke the
+            encoder task for each data URL separately.
         encoder_model_ids: Encoders can take multiple model IDs when the architecture
             supports adapters (e.g., Gemma 3 multimodal projectors). Only used when
             `encoder_fission` is True.
@@ -169,6 +172,7 @@ class MLLMTask(Task[OpenAIChatCompletionRequest, Stream[OpenAIChatCompletionChun
     model_id: str
     modalities: list[Modality] = []
     encoder_fission: bool = True
+    coalesce_encoder_invocations: bool = False
     encoder_model_ids: set[str] | None = None
 
     def post_init(self) -> None:
@@ -197,20 +201,31 @@ class MLLMTask(Task[OpenAIChatCompletionRequest, Stream[OpenAIChatCompletionChun
                     f"{[mod.value for mod in diff]}",
                 )
 
-            # Invoke the encoder tasks for each modality
-            encoder_outputs: dict[Modality, EncoderOutput] = {}
-            for modality, encoder_task in self.encoders.items():
-                if modality not in encoder_input_urls:
-                    continue
-                encoder_input = EncoderInput(model_id=task_input.model, data_urls=encoder_input_urls[modality])
-                encoder_output = encoder_task.invoke(encoder_input)
-                encoder_outputs[modality] = encoder_output
+            # Invoke the encoder tasks
+            if self.coalesce_encoder_invocations:
+                # Coalesce encoder invocations: invoke once per modality with all URLs
+                encoder_outputs: dict[Modality, EncoderOutput] = {}
+                for modality, encoder_task in self.encoders.items():
+                    if modality not in encoder_input_urls:
+                        continue
+                    encoder_input = EncoderInput(model_id=task_input.model, data_urls=encoder_input_urls[modality])
+                    encoder_output = encoder_task.invoke(encoder_input)
+                    encoder_outputs[modality] = encoder_output
 
-            # Retain the order of multimodal data in the task input
-            embeddings: list[DataForward[Tensor]] = []
-            for multimodal_content in multimodal_contents:
-                modality = Modality(multimodal_content.type.split("_")[0])
-                embeddings.append(encoder_outputs[modality].embeddings.pop(0))
+                # Retain the order of multimodal data in the task input
+                embeddings: list[DataForward[Tensor]] = []
+                for multimodal_content in multimodal_contents:
+                    modality = Modality(multimodal_content.type.split("_")[0])
+                    embeddings.append(encoder_outputs[modality].embeddings.pop(0))
+            else:
+                # Separate encoder invocations: invoke encoder for each individual URL
+                embeddings: list[DataForward[Tensor]] = []
+                for multimodal_content in multimodal_contents:
+                    modality = Modality(multimodal_content.type.split("_")[0])
+                    data_url: URL = getattr(multimodal_content, multimodal_content.type)
+                    encoder_input = EncoderInput(model_id=task_input.model, data_urls=[data_url.url])
+                    encoder_output = self.encoders[modality].invoke(encoder_input)
+                    embeddings.append(encoder_output.embeddings[0])
 
             # To be consumed by the LLM task.
             task_input.cornserve_embeddings = embeddings

--- a/python/tests/task/builtins/test_mllm.py
+++ b/python/tests/task/builtins/test_mllm.py
@@ -108,3 +108,95 @@ async def test_mllm_record_concurrent():
     assert invocations2[1].task == task.encoders[Modality.VIDEO]
     assert invocations2[1].task_input.data_urls == ["http://example.com/video.mp4"]
     assert invocations2[2].task == task.llm
+
+
+def test_mllm_coalesce_encoder_invocations_false():
+    """Test MLLM task with coalesce_encoder_invocations=False (separate invocations)."""
+    task = MLLMTask(model_id="llava", modalities=[Modality.IMAGE], coalesce_encoder_invocations=False)
+
+    # Create request with multiple images
+    task_input = OpenAIChatCompletionRequest(
+        model="llava",
+        messages=[
+            ChatCompletionMessageParam(
+                role="user",
+                content=[
+                    ChatCompletionContentPartTextParam(text="Compare these images:"),
+                    ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image1.jpg")),
+                    ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image2.jpg")),
+                    ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image3.jpg")),
+                ],
+            )
+        ],
+    )
+
+    ctx = TaskContext()
+    task_context.set(ctx)
+    with ctx.record():
+        task_output = task.invoke(task_input)
+
+    # Verify the task output is a stream
+    assert isinstance(task_output, Stream)
+
+    # Should have 4 invocations: 3 separate encoder invocations + 1 LLM
+    assert len(ctx.invocations) == 4
+
+    # First three invocations should be separate encoder calls
+    for i in range(3):
+        assert ctx.invocations[i].task == task.encoders[Modality.IMAGE]
+        assert ctx.invocations[i].task_input.data_urls == [f"http://example.com/image{i + 1}.jpg"]
+        assert len(ctx.invocations[i].task_output.embeddings) == 1
+
+    # Fourth invocation should be the LLM
+    assert ctx.invocations[3].task == task.llm
+    assert len(ctx.invocations[3].task_input.cornserve_embeddings) == 3
+
+
+def test_mllm_mixed_modalities_without_coalesce():
+    """Test MLLM task with mixed modalities and coalesce_encoder_invocations=False."""
+    task = MLLMTask(model_id="llava", modalities=[Modality.IMAGE, Modality.VIDEO], coalesce_encoder_invocations=False)
+
+    # Create request with multiple images and videos
+    task_input = OpenAIChatCompletionRequest(
+        model="llava",
+        messages=[
+            ChatCompletionMessageParam(
+                role="user",
+                content=[
+                    ChatCompletionContentPartTextParam(text="Analyze this content:"),
+                    ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image1.jpg")),
+                    ChatCompletionContentPartVideoParam(video_url=URL(url="http://example.com/video1.mp4")),
+                    ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image2.jpg")),
+                    ChatCompletionContentPartVideoParam(video_url=URL(url="http://example.com/video2.mp4")),
+                ],
+            )
+        ],
+    )
+
+    ctx = TaskContext()
+    task_context.set(ctx)
+    with ctx.record():
+        task_output = task.invoke(task_input)
+
+    # Verify the task output is a stream
+    assert isinstance(task_output, Stream)
+
+    # Should have 5 invocations: 4 separate encoder invocations + 1 LLM
+    assert len(ctx.invocations) == 5
+
+    # Verify each encoder invocation is separate and in order
+    expected_calls = [
+        (task.encoders[Modality.IMAGE], ["http://example.com/image1.jpg"]),
+        (task.encoders[Modality.VIDEO], ["http://example.com/video1.mp4"]),
+        (task.encoders[Modality.IMAGE], ["http://example.com/image2.jpg"]),
+        (task.encoders[Modality.VIDEO], ["http://example.com/video2.mp4"]),
+    ]
+
+    for i, (expected_task, expected_urls) in enumerate(expected_calls):
+        assert ctx.invocations[i].task == expected_task
+        assert ctx.invocations[i].task_input.data_urls == expected_urls
+        assert len(ctx.invocations[i].task_output.embeddings) == 1
+
+    # Fifth invocation should be the LLM
+    assert ctx.invocations[4].task == task.llm
+    assert len(ctx.invocations[4].task_input.cornserve_embeddings) == 4

--- a/python/tests/task/builtins/test_mllm.py
+++ b/python/tests/task/builtins/test_mllm.py
@@ -18,19 +18,22 @@ from cornserve.task.builtins.llm import (
 from cornserve.task.forward import DataForward, ForwardableType, Tensor
 
 
-def test_mllm_record():
-    """Test MLLM task invocation recording."""
-    task = MLLMTask(model_id="llava", modalities=[Modality.IMAGE])
+def test_mllm_task():
+    """Test MLLM task with mixed modalities and coalesce_encoder_invocations=False."""
+    task = MLLMTask(model_id="llava", modalities=[Modality.IMAGE, Modality.VIDEO], coalesce_encoder_invocations=False)
 
-    # Create OpenAI-compatible chat completion request with image
+    # Create request with multiple images and videos
     task_input = OpenAIChatCompletionRequest(
         model="llava",
         messages=[
             ChatCompletionMessageParam(
                 role="user",
                 content=[
-                    ChatCompletionContentPartTextParam(text="Hello, world!"),
-                    ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image.jpg")),
+                    ChatCompletionContentPartTextParam(text="Analyze this content:"),
+                    ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image1.jpg")),
+                    ChatCompletionContentPartVideoParam(video_url=URL(url="http://example.com/video1.mp4")),
+                    ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image2.jpg")),
+                    ChatCompletionContentPartVideoParam(video_url=URL(url="http://example.com/video2.mp4")),
                 ],
             )
         ],
@@ -44,18 +47,30 @@ def test_mllm_record():
     # Verify the task output is a stream
     assert isinstance(task_output, Stream)
 
-    assert len(ctx.invocations) == 2
-    assert ctx.invocations[0].task == task.encoders[Modality.IMAGE]
-    assert ctx.invocations[0].task_input.data_urls == ["http://example.com/image.jpg"]
-    assert len(ctx.invocations[0].task_output.embeddings) == 1
-    assert (
-        ctx.invocations[0].task_output.embeddings[0].data_type
-        == DataForward[Tensor]().data_type
-        == ForwardableType.TENSOR
-    )
-    assert ctx.invocations[1].task == task.llm
-    assert len(ctx.invocations[1].task_input.cornserve_embeddings) == 1
-    assert ctx.invocations[0].task_output.embeddings[0] == ctx.invocations[1].task_input.cornserve_embeddings[0]
+    # Should have 5 invocations: 4 separate encoder invocations + 1 LLM
+    assert len(ctx.invocations) == 5
+
+    # Verify each encoder invocation is separate and in order
+    expected_calls = [
+        (task.encoders[Modality.IMAGE], ["http://example.com/image1.jpg"]),
+        (task.encoders[Modality.VIDEO], ["http://example.com/video1.mp4"]),
+        (task.encoders[Modality.IMAGE], ["http://example.com/image2.jpg"]),
+        (task.encoders[Modality.VIDEO], ["http://example.com/video2.mp4"]),
+    ]
+
+    for i, (expected_task, expected_urls) in enumerate(expected_calls):
+        assert ctx.invocations[i].task == expected_task
+        assert ctx.invocations[i].task_input.data_urls == expected_urls
+        assert len(ctx.invocations[i].task_output.embeddings) == 1
+        assert (
+            ctx.invocations[i].task_output.embeddings[0].data_type
+            == DataForward[Tensor]().data_type
+            == ForwardableType.TENSOR
+        )
+
+    # Fifth invocation should be the LLM
+    assert ctx.invocations[4].task == task.llm
+    assert len(ctx.invocations[4].task_input.cornserve_embeddings) == 4
 
 
 @pytest.mark.asyncio
@@ -110,21 +125,21 @@ async def test_mllm_record_concurrent():
     assert invocations2[2].task == task.llm
 
 
-def test_mllm_coalesce_encoder_invocations_false():
-    """Test MLLM task with coalesce_encoder_invocations=False (separate invocations)."""
-    task = MLLMTask(model_id="llava", modalities=[Modality.IMAGE], coalesce_encoder_invocations=False)
+def test_mllm_mixed_modalities_coalesce():
+    """Test MLLM task invocation with encoder invocation coalescing."""
+    task = MLLMTask(model_id="llava", modalities=[Modality.IMAGE, Modality.VIDEO], coalesce_encoder_invocations=True)
 
-    # Create request with multiple images
+    # Create OpenAI-compatible chat completion request with image
     task_input = OpenAIChatCompletionRequest(
         model="llava",
         messages=[
             ChatCompletionMessageParam(
                 role="user",
                 content=[
-                    ChatCompletionContentPartTextParam(text="Compare these images:"),
+                    ChatCompletionContentPartTextParam(text="Hello, world!"),
                     ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image1.jpg")),
                     ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image2.jpg")),
-                    ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image3.jpg")),
+                    ChatCompletionContentPartVideoParam(video_url=URL(url="http://example.com/video.mp4")),
                 ],
             )
         ],
@@ -138,65 +153,27 @@ def test_mllm_coalesce_encoder_invocations_false():
     # Verify the task output is a stream
     assert isinstance(task_output, Stream)
 
-    # Should have 4 invocations: 3 separate encoder invocations + 1 LLM
-    assert len(ctx.invocations) == 4
-
-    # First three invocations should be separate encoder calls
-    for i in range(3):
-        assert ctx.invocations[i].task == task.encoders[Modality.IMAGE]
-        assert ctx.invocations[i].task_input.data_urls == [f"http://example.com/image{i + 1}.jpg"]
-        assert len(ctx.invocations[i].task_output.embeddings) == 1
-
-    # Fourth invocation should be the LLM
-    assert ctx.invocations[3].task == task.llm
-    assert len(ctx.invocations[3].task_input.cornserve_embeddings) == 3
-
-
-def test_mllm_mixed_modalities_without_coalesce():
-    """Test MLLM task with mixed modalities and coalesce_encoder_invocations=False."""
-    task = MLLMTask(model_id="llava", modalities=[Modality.IMAGE, Modality.VIDEO], coalesce_encoder_invocations=False)
-
-    # Create request with multiple images and videos
-    task_input = OpenAIChatCompletionRequest(
-        model="llava",
-        messages=[
-            ChatCompletionMessageParam(
-                role="user",
-                content=[
-                    ChatCompletionContentPartTextParam(text="Analyze this content:"),
-                    ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image1.jpg")),
-                    ChatCompletionContentPartVideoParam(video_url=URL(url="http://example.com/video1.mp4")),
-                    ChatCompletionContentPartImageParam(image_url=URL(url="http://example.com/image2.jpg")),
-                    ChatCompletionContentPartVideoParam(video_url=URL(url="http://example.com/video2.mp4")),
-                ],
-            )
-        ],
+    assert len(ctx.invocations) == 3
+    assert ctx.invocations[0].task == task.encoders[Modality.IMAGE]
+    assert ctx.invocations[0].task_input.data_urls == ["http://example.com/image1.jpg", "http://example.com/image2.jpg"]
+    assert len(ctx.invocations[0].task_output.embeddings) == 2
+    assert (
+        ctx.invocations[0].task_output.embeddings[0].data_type
+        == DataForward[Tensor]().data_type
+        == ForwardableType.TENSOR
     )
 
-    ctx = TaskContext()
-    task_context.set(ctx)
-    with ctx.record():
-        task_output = task.invoke(task_input)
+    assert ctx.invocations[1].task == task.encoders[Modality.VIDEO]
+    assert ctx.invocations[1].task == task.encoders[Modality.VIDEO]
+    assert ctx.invocations[1].task_input.data_urls == ["http://example.com/video.mp4"]
+    assert len(ctx.invocations[1].task_output.embeddings) == 1
+    assert (
+        ctx.invocations[1].task_output.embeddings[0].data_type
+        == DataForward[Tensor]().data_type
+        == ForwardableType.TENSOR
+    )
 
-    # Verify the task output is a stream
-    assert isinstance(task_output, Stream)
-
-    # Should have 5 invocations: 4 separate encoder invocations + 1 LLM
-    assert len(ctx.invocations) == 5
-
-    # Verify each encoder invocation is separate and in order
-    expected_calls = [
-        (task.encoders[Modality.IMAGE], ["http://example.com/image1.jpg"]),
-        (task.encoders[Modality.VIDEO], ["http://example.com/video1.mp4"]),
-        (task.encoders[Modality.IMAGE], ["http://example.com/image2.jpg"]),
-        (task.encoders[Modality.VIDEO], ["http://example.com/video2.mp4"]),
-    ]
-
-    for i, (expected_task, expected_urls) in enumerate(expected_calls):
-        assert ctx.invocations[i].task == expected_task
-        assert ctx.invocations[i].task_input.data_urls == expected_urls
-        assert len(ctx.invocations[i].task_output.embeddings) == 1
-
-    # Fifth invocation should be the LLM
-    assert ctx.invocations[4].task == task.llm
-    assert len(ctx.invocations[4].task_input.cornserve_embeddings) == 4
+    assert ctx.invocations[2].task == task.llm
+    assert ctx.invocations[0].task_output.embeddings[0] == ctx.invocations[2].task_input.cornserve_embeddings[0]
+    assert ctx.invocations[0].task_output.embeddings[1] == ctx.invocations[2].task_input.cornserve_embeddings[1]
+    assert ctx.invocations[2].task_output == task_output

--- a/python/tests/task/builtins/test_mllm.py
+++ b/python/tests/task/builtins/test_mllm.py
@@ -164,7 +164,6 @@ def test_mllm_mixed_modalities_coalesce():
     )
 
     assert ctx.invocations[1].task == task.encoders[Modality.VIDEO]
-    assert ctx.invocations[1].task == task.encoders[Modality.VIDEO]
     assert ctx.invocations[1].task_input.data_urls == ["http://example.com/video.mp4"]
     assert len(ctx.invocations[1].task_output.embeddings) == 1
     assert (

--- a/python/tests/task/test_base.py
+++ b/python/tests/task/test_base.py
@@ -101,7 +101,7 @@ def test_serde_one():
 def test_serde_graph():
     """Tests whether task graph invocations can be serialized and deserialized."""
     encoder_invocation = TaskInvocation(
-        task=EncoderTask(model_id="clip", modality=Modality.IMAGE),
+        task=EncoderTask(model_ids={"clip"}, modality=Modality.IMAGE),
         task_input=EncoderInput(model_id="clip", data_urls=["https://example.com/image.jpg"]),
         task_output=EncoderOutput(embeddings=[DataForward[Tensor]()]),
     )
@@ -126,11 +126,11 @@ def test_task_equivalence():
     """Tests whether unit task equivalence is determined correctly."""
     assert LLMUnitTask(model_id="llama").is_equivalent_to(LLMUnitTask(model_id="llama"))
     assert not LLMUnitTask(model_id="llama").is_equivalent_to(LLMUnitTask(model_id="mistral"))
-    assert EncoderTask(model_id="clip", modality=Modality.IMAGE).is_equivalent_to(
-        EncoderTask(model_id="clip", modality=Modality.IMAGE)
+    assert EncoderTask(model_ids={"clip"}, modality=Modality.IMAGE).is_equivalent_to(
+        EncoderTask(model_ids={"clip"}, modality=Modality.IMAGE)
     )
-    assert not EncoderTask(model_id="clip", modality=Modality.IMAGE).is_equivalent_to(
-        EncoderTask(model_id="clip", modality=Modality.VIDEO)
+    assert not EncoderTask(model_ids={"clip"}, modality=Modality.IMAGE).is_equivalent_to(
+        EncoderTask(model_ids={"clip"}, modality=Modality.VIDEO)
     )
 
 

--- a/python/tests/task/test_subtasks.py
+++ b/python/tests/task/test_subtasks.py
@@ -49,8 +49,7 @@ class ArenaTask(Task[ArenaInput, ArenaOutput]):
         """
         EncoderTask(
             modality=self.modality,
-            model_id=list(self.models.values())[0],
-            adapter_model_ids=list(self.models.values())[1:],
+            model_ids=set(self.models.values()),
         )
 
         MLLMTask(
@@ -81,7 +80,7 @@ def test_arena_task_registration():
 
     encoder = getattr(task, "__subtask_0__")
     assert isinstance(encoder, EncoderTask)
-    assert encoder.model_id == "llama-7B"
+    assert encoder.model_ids == {"llama-7B", "gemma-4B"}
     assert encoder.modality == Modality.IMAGE
 
     mllm = getattr(task, "__subtask_1__")
@@ -94,7 +93,7 @@ def test_arena_task_registration():
 
     mllm_encoder = getattr(mllm, "__subtask_0__")
     assert isinstance(mllm_encoder, EncoderTask)
-    assert mllm_encoder.model_id == "gemma-4B"
+    assert mllm_encoder.model_ids == {"gemma-4B"}
     assert mllm_encoder.modality == Modality.IMAGE
 
     mllm_llm = getattr(mllm, "__subtask_1__")


### PR DESCRIPTION
- The `MLLMTask` has a new config variable called `coalesce_encoder_invocations: bool`. If it's true, it'll coalesce encoder invocations of the same modality into a single `EncoderTask` invocation. If false, it'll split each multimodal input into a separate `EncoderTask` invocation. The previous behavior is the former, and the new default behavior is the latter.
- The Task Manager now does Round Robin routing by default.