### PR TITLE
[*] Switch from `httpx` to `aiohttp`

### DIFF
--- a/python/cornserve/services/gateway/entrypoint.py
+++ b/python/cornserve/services/gateway/entrypoint.py
@@ -8,9 +8,9 @@ import signal
 from typing import TYPE_CHECKING
 
 import uvicorn
+from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.grpc import GrpcAioInstrumentorClient
-from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
 from cornserve.logging import get_logger
 from cornserve.services.gateway.router import create_app
@@ -31,7 +31,7 @@ async def serve() -> None:
     app = create_app()
     FastAPIInstrumentor.instrument_app(app)
     GrpcAioInstrumentorClient().instrument()
-    HTTPXClientInstrumentor().instrument()
+    AioHttpClientInstrumentor().instrument()
 
     logger.info("Available routes are:")
     for route in app.routes:

--- a/python/cornserve/services/gateway/task_manager.py
+++ b/python/cornserve/services/gateway/task_manager.py
@@ -289,4 +289,7 @@ class TaskManager:
         # Close the gRPC channel to the resource manager
         await self.resource_manager_channel.close()
 
+        # Close the HTTP client session
+        await self.client.close()
+
         logger.info("Gateway task manager has been shut down")

--- a/python/cornserve/services/gateway/task_manager.py
+++ b/python/cornserve/services/gateway/task_manager.py
@@ -8,8 +8,8 @@ import uuid
 from collections import defaultdict
 from typing import Any
 
+import aiohttp
 import grpc
-import httpx
 from opentelemetry import trace
 
 from cornserve.constants import K8S_TASK_DISPATCHER_HTTP_URL
@@ -53,7 +53,7 @@ class TaskManager:
         self.task_lock = asyncio.Lock()
 
         # HTTP client
-        self.client = httpx.AsyncClient(timeout=TASK_TIMEOUT)
+        self.client = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=TASK_TIMEOUT))
 
         # Task-related state. Key is the task ID.
         self.tasks: dict[str, UnitTask] = {}

--- a/python/cornserve/services/task_dispatcher/dispatcher.py
+++ b/python/cornserve/services/task_dispatcher/dispatcher.py
@@ -9,8 +9,8 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
+import aiohttp
 import grpc
-import httpx
 from opentelemetry import trace
 from pydantic import BaseModel
 
@@ -97,7 +97,7 @@ class TaskDispatcher:
 
         self.ongoing_task_lock = asyncio.Lock()
         self.ongoing_invokes: dict[str, list[asyncio.Task]] = defaultdict(list)
-        self.client = httpx.AsyncClient(timeout=TASK_TIMEOUT)
+        self.client = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=TASK_TIMEOUT))
 
     async def notify_task_deployment(self, task: UnitTask, task_manager_url: str) -> None:
         """Register a newly deployed task and its task manager with the dispatcher."""
@@ -143,7 +143,7 @@ class TaskDispatcher:
             if isinstance(result, BaseException):
                 logger.error("Error occured while shutting down task dispatcher: %s", result)
 
-        await self.client.aclose()
+        await self.client.close()
 
         logger.info("Task dispatcher shutdown complete")
 
@@ -276,31 +276,26 @@ class TaskDispatcher:
             execution.invocation.task.__class__.__name__,
             request,
         )
-        request_obj = self.client.build_request(method="POST", url=url, json=request)
         try:
-            if execution.is_streaming:
-                response = await self.client.send(request_obj, stream=True)
-            else:
-                response = await self.client.send(request_obj, stream=False)
+            response = await self.client.post(url, json=request)
             response.raise_for_status()
-        except httpx.HTTPStatusError as e:
+            logger.info(
+                "Task %s response: %s",
+                execution.invocation.task.__class__.__name__,
+                "[Stream]" if execution.is_streaming else await response.text(),
+            )
+        except aiohttp.ClientResponseError as e:
             logger.exception("Error while invoking task")
             raise RuntimeError(
-                f"HTTP request failed with code {e.response.status_code}: {e.response}",
+                f"HTTP request failed with code {e.status}: {e.message}",
             ) from e
         except Exception as e:
             logger.exception("Error while invoking task")
             raise RuntimeError(f"HTTP request failed: {e}") from e
 
-        logger.info(
-            "Task %s response: %s",
-            execution.invocation.task.__class__.__name__,
-            "[Stream]" if execution.is_streaming else response.content.decode(),
-        )
-
         # HTTP response from the Task Executor is converted to TaskOutput.
         # For streaming tasks, `task_output` is a Stream object.
-        task_output: TaskOutput = execution.invocation.task.execution_descriptor.from_response(
+        task_output: TaskOutput = await execution.invocation.task.execution_descriptor.from_response(
             task_output=execution.invocation.task_output,
             response=response,
         )

--- a/python/cornserve/services/task_dispatcher/entrypoint.py
+++ b/python/cornserve/services/task_dispatcher/entrypoint.py
@@ -7,9 +7,9 @@ import signal
 from typing import TYPE_CHECKING
 
 import uvicorn
+from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.grpc import GrpcInstrumentorClient, GrpcInstrumentorServer
-from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
 from cornserve.logging import get_logger
 from cornserve.services.task_dispatcher.grpc import create_server
@@ -32,7 +32,7 @@ async def serve() -> None:
     app = create_app()
 
     FastAPIInstrumentor.instrument_app(app)
-    HTTPXClientInstrumentor().instrument()
+    AioHttpClientInstrumentor().instrument()
     GrpcInstrumentorClient().instrument()
     GrpcInstrumentorServer().instrument()
 

--- a/python/cornserve/task/base.py
+++ b/python/cornserve/task/base.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Self, TypeVar, final
 
-import httpx
+import aiohttp
 from opentelemetry import trace
 from pydantic import BaseModel, ConfigDict, Field, model_serializer, model_validator
 
@@ -34,7 +34,16 @@ tracer = trace.get_tracer(__name__)
 TASK_TIMEOUT = 300
 
 # Global shared HTTP client used when we are outside of the Gateway service.
-CLIENT = httpx.AsyncClient(timeout=TASK_TIMEOUT)
+_CLIENT: aiohttp.ClientSession | None = None
+
+
+def get_client() -> aiohttp.ClientSession:
+    """Get or create the global HTTP client."""
+    global _CLIENT
+    if _CLIENT is None or _CLIENT.closed:
+        _CLIENT = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=TASK_TIMEOUT))
+    return _CLIENT
+
 
 # This context variable is set inside the top-level task's `__call__` method
 # just before creating an `asyncio.Task` (`_call_impl`) to run the task.
@@ -74,7 +83,7 @@ class Stream(TaskOutput, Generic[OutputT]):
 
     # Each line in the stream should be a JSON string that can be parsed into an `OutputT` object.
     async_iterator: AsyncIterator[str] | None = Field(default=None, exclude=True)
-    response: httpx.Response | None = Field(default=None, exclude=True)
+    response: aiohttp.ClientResponse | None = Field(default=None, exclude=True)
 
     _prev_type: type[TaskOutput] | None = None
     _transform_func: Callable[[TaskOutput], OutputT] | None = None
@@ -137,7 +146,7 @@ class Stream(TaskOutput, Generic[OutputT]):
             # Close the connection at exit.
             if self.response is not None:
                 try:
-                    await self.response.aclose()
+                    self.response.close()
                 except Exception as e:
                     logger.warning("Failed to close stream response: %s", e)
 
@@ -556,7 +565,7 @@ class TaskGraphDispatch(BaseModel):
         self.is_streaming = isinstance(self.invocations[-1].task_output, Stream)
 
     @tracer.start_as_current_span("TaskGraphDispatch.dispatch")
-    async def dispatch(self, url: str, client: httpx.AsyncClient) -> list[Any]:
+    async def dispatch(self, url: str, client: aiohttp.ClientSession) -> list[Any]:
         """Dispatch the task graph and wait for the response.
 
         Returns a list of task outputs. Each task output is deserialized from JSON,
@@ -569,10 +578,9 @@ class TaskGraphDispatch(BaseModel):
 
         try:
             if self.is_streaming:
-                request_obj = client.build_request(method="POST", url=url, json=self.model_dump())
-                response = await client.send(request_obj, stream=True)
+                response = await client.post(url, json=self.model_dump())
                 response.raise_for_status()
-                ait = response.aiter_lines()
+                ait = aiter(response.content)
 
                 # First line is the task outputs of all invocations.
                 try:
@@ -588,15 +596,15 @@ class TaskGraphDispatch(BaseModel):
                 assert issubclass(stream_cls, Stream), "Last invocation output must be a Stream."
                 _ = stream_cls.model_validate(dispatch_outputs[-1])  # validation
             else:
-                response = await client.post(url, json=self.model_dump())
-                response.raise_for_status()
-                dispatch_outputs = response.json()
-        except httpx.RequestError as e:
-            logger.exception("Failed to send dispatch request to %s: %s", url, e)
-            raise RuntimeError(f"Failed to send dispatch request to {url}.") from e
-        except httpx.HTTPStatusError as e:
+                async with client.post(url, json=self.model_dump()) as response:
+                    response.raise_for_status()
+                    dispatch_outputs = await response.json()
+        except aiohttp.ClientResponseError as e:
             logger.exception("Received error response from %s: %s", url, e)
             raise RuntimeError(f"Received error response from {url}.") from e
+        except aiohttp.ClientError as e:
+            logger.exception("Failed to send dispatch request to %s: %s", url, e)
+            raise RuntimeError(f"Failed to send dispatch request to {url}.") from e
 
         if not isinstance(dispatch_outputs, list):
             raise RuntimeError(f"Expected a list of task outputs, but got {type(dispatch_outputs)}.")
@@ -708,7 +716,7 @@ class TaskContext:
 
             logger.info("Dispatching tasks to %s/tasks/invoke", gateway_url)
 
-            dispatch_outputs = await graph_dispatch.dispatch(gateway_url + "/tasks/invoke", client=CLIENT)
+            dispatch_outputs = await graph_dispatch.dispatch(gateway_url + "/tasks/invoke", client=get_client())
 
         # We're inside the Gateway service.
         else:

--- a/python/cornserve/task_executors/descriptor/base.py
+++ b/python/cornserve/task_executors/descriptor/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
-import httpx
+import aiohttp
 import kubernetes_asyncio.client as kclient
 from pydantic import BaseModel
 
@@ -83,7 +83,7 @@ class TaskExecutionDescriptor(BaseModel, ABC, Generic[TaskT, InputT, OutputT]):
         """
 
     @abstractmethod
-    def from_response(self, task_output: OutputT, response: httpx.Response) -> OutputT:
+    async def from_response(self, task_output: OutputT, response: aiohttp.ClientResponse) -> OutputT:
         """Convert the task executor response to TaskOutput.
 
         In general, the `task_output` object will be deep-copied and concrete values

--- a/python/cornserve/task_executors/descriptor/builtins/encoder.py
+++ b/python/cornserve/task_executors/descriptor/builtins/encoder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import httpx
+import aiohttp
 
 from cornserve import constants
 from cornserve.services.resource import GPU
@@ -70,9 +70,10 @@ class EricDescriptor(TaskExecutionDescriptor[EncoderTask, EncoderInput, EncoderO
         req = EmbeddingRequest(data=data)
         return req.model_dump()
 
-    def from_response(self, task_output: EncoderOutput, response: httpx.Response) -> EncoderOutput:
+    async def from_response(self, task_output: EncoderOutput, response: aiohttp.ClientResponse) -> EncoderOutput:
         """Convert the task executor response to TaskOutput."""
-        resp = EmbeddingResponse.model_validate(response.json())
+        response_data = await response.json()
+        resp = EmbeddingResponse.model_validate(response_data)
         if resp.status == Status.SUCCESS:
             return EncoderOutput(embeddings=task_output.embeddings)
         else:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "tyro",
   "kubernetes",
   "kubernetes_asyncio",
-  "httpx",
+  "aiohttp",
   "pydantic>=2.11",
   "opentelemetry-api",
   "opentelemetry-sdk",
@@ -55,7 +55,7 @@ gateway = [
   "uvicorn[standard]",
   "opentelemetry-instrumentation-fastapi",
   "opentelemetry-instrumentation-grpc",
-  "opentelemetry-instrumentation-httpx",
+  "opentelemetry-instrumentation-aiohttp-client",
   "websocket-client",
 ]
 resource-manager = [
@@ -66,7 +66,7 @@ task-dispatcher = [
   "fastapi",
   "uvicorn[standard]",
   "opentelemetry-instrumentation-fastapi",
-  "opentelemetry-instrumentation-httpx",
+  "opentelemetry-instrumentation-aiohttp-client",
   "opentelemetry-instrumentation-grpc",
 ]
 audio = ["librosa"]


### PR DESCRIPTION
We have seen issues similar to https://github.com/encode/httpx/issues/3348, so we're switching to `aiohttp`.

I've tested this on a single node with the`mllm.py` and `gemmarena.py` examples.