### PR TITLE
[Control plane] Unlimited connections for `aiohttp` client sessions

### DIFF
--- a/python/cornserve/services/gateway/task_manager.py
+++ b/python/cornserve/services/gateway/task_manager.py
@@ -53,7 +53,10 @@ class TaskManager:
         self.task_lock = asyncio.Lock()
 
         # HTTP client
-        self.client = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=TASK_TIMEOUT))
+        self.client = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=TASK_TIMEOUT),
+            connector=aiohttp.TCPConnector(limit=0),
+        )
 
         # Task-related state. Key is the task ID.
         self.tasks: dict[str, UnitTask] = {}

--- a/python/cornserve/services/task_dispatcher/dispatcher.py
+++ b/python/cornserve/services/task_dispatcher/dispatcher.py
@@ -97,7 +97,10 @@ class TaskDispatcher:
 
         self.ongoing_task_lock = asyncio.Lock()
         self.ongoing_invokes: dict[str, list[asyncio.Task]] = defaultdict(list)
-        self.client = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=TASK_TIMEOUT))
+        self.client = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=TASK_TIMEOUT),
+            connector=aiohttp.TCPConnector(limit=0),
+        )
 
     async def notify_task_deployment(self, task: UnitTask, task_manager_url: str) -> None:
         """Register a newly deployed task and its task manager with the dispatcher."""

--- a/python/cornserve/task/base.py
+++ b/python/cornserve/task/base.py
@@ -41,7 +41,10 @@ def get_client() -> aiohttp.ClientSession:
     """Get or create the global HTTP client."""
     global _CLIENT
     if _CLIENT is None or _CLIENT.closed:
-        _CLIENT = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=TASK_TIMEOUT))
+        _CLIENT = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=TASK_TIMEOUT),
+            connector=aiohttp.TCPConnector(limit=0),
+        )
     return _CLIENT
 
 


### PR DESCRIPTION
To prevent high request rates from being bottlenecekd by the control plane's HTTP client library