### PR TITLE
[Task, vLLM] `CORNSERVE_VLLM_DISABLE_MULTIMODAL`

### DIFF
--- a/python/cornserve/task_executors/descriptor/builtins/llm.py
+++ b/python/cornserve/task_executors/descriptor/builtins/llm.py
@@ -195,12 +195,17 @@ class PrefillVLLMDescriptor(
 
     def get_container_envs(self, gpus: list[GPU]) -> list[tuple[str, str]]:
         """Get the additional environment variables for the task executor."""
-        return [
+        envs = [
             # ("UCX_LOG_LEVEL", "debug"),
             # ("VLLM_LOGGING_LEVEL", "DEBUG"),
             ("CUDA_VISIBLE_DEVICES", ",".join(str(gpu.local_rank) for gpu in gpus)),
             ("VLLM_NIXL_SIDE_CHANNEL_PORT", str(self.NIXL_BASE_PORT + gpus[0].global_rank)),
         ]
+        if not self.task.receive_embeddings:
+            envs.append(
+                ("CORNSERVE_VLLM_DISABLE_MULTIMODAL", "1"),
+            )
+        return envs
 
     def get_kubernetes_envs(self, gpus: list[GPU]) -> list[kclient.V1EnvVar]:
         """Get the kubernetes environment variables for the task executor."""
@@ -333,12 +338,17 @@ class DecodeVLLMDescriptor(
 
     def get_container_envs(self, gpus: list[GPU]) -> list[tuple[str, str]]:
         """Get the additional environment variables for the task executor."""
-        return [
+        envs = [
             # ("UCX_LOG_LEVEL", "debug"),
             # ("VLLM_LOGGING_LEVEL", "DEBUG"),
             ("CUDA_VISIBLE_DEVICES", ",".join(str(gpu.local_rank) for gpu in gpus)),
             ("VLLM_NIXL_SIDE_CHANNEL_PORT", str(self.NIXL_BASE_PORT + gpus[0].global_rank)),
         ]
+        if not self.task.receive_embeddings:
+            envs.append(
+                ("CORNSERVE_VLLM_DISABLE_MULTIMODAL", "1"),
+            )
+        return envs
 
     def get_kubernetes_envs(self, gpus: list[GPU]) -> list[kclient.V1EnvVar]:
         """Get the kubernetes environment variables for the task executor."""

--- a/python/cornserve/task_executors/descriptor/builtins/llm.py
+++ b/python/cornserve/task_executors/descriptor/builtins/llm.py
@@ -73,6 +73,15 @@ class VLLMDescriptor(
         """Get the container image name for the task executor."""
         return constants.CONTAINER_IMAGE_VLLM
 
+    def get_container_envs(self, gpus: list[GPU]) -> list[tuple[str, str]]:
+        """Get the container environment variables for the task executor."""
+        envs = super().get_container_envs(gpus)
+        if not self.task.receive_embeddings:
+            envs.append(
+                ("CORNSERVE_VLLM_DISABLE_MULTIMODAL", "1"),
+            )
+        return envs
+
     def get_container_args(self, gpus: list[GPU], port: int) -> list[str]:
         """Get the container command for the task executor."""
         args = [

--- a/python/cornserve/task_executors/descriptor/builtins/llm.py
+++ b/python/cornserve/task_executors/descriptor/builtins/llm.py
@@ -76,7 +76,7 @@ class VLLMDescriptor(
     def get_container_envs(self, gpus: list[GPU]) -> list[tuple[str, str]]:
         """Get the container environment variables for the task executor."""
         envs = super().get_container_envs(gpus)
-        if not self.task.receive_embeddings:
+        if self.task.receive_embeddings:
             envs.append(
                 ("CORNSERVE_VLLM_DISABLE_MULTIMODAL", "1"),
             )
@@ -201,7 +201,7 @@ class PrefillVLLMDescriptor(
             ("CUDA_VISIBLE_DEVICES", ",".join(str(gpu.local_rank) for gpu in gpus)),
             ("VLLM_NIXL_SIDE_CHANNEL_PORT", str(self.NIXL_BASE_PORT + gpus[0].global_rank)),
         ]
-        if not self.task.receive_embeddings:
+        if self.task.receive_embeddings:
             envs.append(
                 ("CORNSERVE_VLLM_DISABLE_MULTIMODAL", "1"),
             )
@@ -344,7 +344,7 @@ class DecodeVLLMDescriptor(
             ("CUDA_VISIBLE_DEVICES", ",".join(str(gpu.local_rank) for gpu in gpus)),
             ("VLLM_NIXL_SIDE_CHANNEL_PORT", str(self.NIXL_BASE_PORT + gpus[0].global_rank)),
         ]
-        if not self.task.receive_embeddings:
+        if self.task.receive_embeddings:
             envs.append(
                 ("CORNSERVE_VLLM_DISABLE_MULTIMODAL", "1"),
             )

--- a/python/cornserve/task_executors/descriptor/builtins/llm.py
+++ b/python/cornserve/task_executors/descriptor/builtins/llm.py
@@ -195,12 +195,14 @@ class PrefillVLLMDescriptor(
 
     def get_container_envs(self, gpus: list[GPU]) -> list[tuple[str, str]]:
         """Get the additional environment variables for the task executor."""
-        envs = [
-            # ("UCX_LOG_LEVEL", "debug"),
-            # ("VLLM_LOGGING_LEVEL", "DEBUG"),
-            ("CUDA_VISIBLE_DEVICES", ",".join(str(gpu.local_rank) for gpu in gpus)),
-            ("VLLM_NIXL_SIDE_CHANNEL_PORT", str(self.NIXL_BASE_PORT + gpus[0].global_rank)),
-        ]
+        envs = super().get_container_envs(gpus)
+        envs.extend(
+            [
+                # ("UCX_LOG_LEVEL", "debug"),
+                # ("VLLM_LOGGING_LEVEL", "DEBUG"),
+                ("VLLM_NIXL_SIDE_CHANNEL_PORT", str(self.NIXL_BASE_PORT + gpus[0].global_rank)),
+            ]
+        )
         if self.task.receive_embeddings:
             envs.append(
                 ("CORNSERVE_VLLM_DISABLE_MULTIMODAL", "1"),
@@ -338,12 +340,14 @@ class DecodeVLLMDescriptor(
 
     def get_container_envs(self, gpus: list[GPU]) -> list[tuple[str, str]]:
         """Get the additional environment variables for the task executor."""
-        envs = [
-            # ("UCX_LOG_LEVEL", "debug"),
-            # ("VLLM_LOGGING_LEVEL", "DEBUG"),
-            ("CUDA_VISIBLE_DEVICES", ",".join(str(gpu.local_rank) for gpu in gpus)),
-            ("VLLM_NIXL_SIDE_CHANNEL_PORT", str(self.NIXL_BASE_PORT + gpus[0].global_rank)),
-        ]
+        envs = super().get_container_envs(gpus)
+        envs.extend(
+            [
+                # ("UCX_LOG_LEVEL", "debug"),
+                # ("VLLM_LOGGING_LEVEL", "DEBUG"),
+                ("VLLM_NIXL_SIDE_CHANNEL_PORT", str(self.NIXL_BASE_PORT + gpus[0].global_rank)),
+            ]
+        )
         if self.task.receive_embeddings:
             envs.append(
                 ("CORNSERVE_VLLM_DISABLE_MULTIMODAL", "1"),


### PR DESCRIPTION
Setting the `CORNSERVE_VLLM_DISABLE_MULTIMODAL` environment variable for cornserve-vllm (current branch `jm-pd`) will disable the InternVL model's vision encoder. This PR makes the vLLM descriptors (monolithic, prefill, and decode) set that environment variable when the encoder is disaggregated (i.e., when `self.task.receive_embeddings` is `True`).