### PR TITLE
Sidecar supports MarkDoneAll/UnlinkAll and retries on failed requests

### DIFF
--- a/proto/v1/sidecar.proto
+++ b/proto/v1/sidecar.proto
@@ -24,10 +24,19 @@ service Sidecar {
   // Mark a chunk of forwarded data as done.
   rpc MarkDone(MarkDoneRequest) returns (MarkDoneResponse);
 
+  // Consumer sidecar client --> Its sidecar server (==> Producer sidecar server).
+  // Mark all chunks of forwarded data as done for a given data_id.
+  rpc MarkDoneAll(MarkDoneAllRequest) returns (MarkDoneAllResponse);
+
   // Consumer sidecar server --> Producer sidecar server.
   // Used exclusively during intra-node /dev/shm ping-pong.
   // Decrement the reference count of a chunk.
   rpc Unlink(UnlinkRequest) returns (UnlinkResponse);
+
+  // Consumer sidecar server --> Producer sidecar server.
+  // Used exclusively during intra-node /dev/shm ping-pong.
+  // Decrement the reference count of all chunks for a given data_id.
+  rpc UnlinkAll(UnlinkAllRequest) returns (UnlinkAllResponse);
 
   // Producer sidecar server --> Consumer sidecar server.
   // Ask the receiver sidecar to prepare for receiving a chunk of data,
@@ -108,6 +117,15 @@ message MarkDoneResponse {
   common.Status status = 1;
 }
 
+message MarkDoneAllRequest {
+  string id = 1;
+}
+
+message MarkDoneAllResponse {
+  common.Status status = 1;
+  int32 num_chunks_marked = 2;  // number of chunks that were marked done
+}
+
 message UnlinkRequest {
   string id = 1;
   int32 chunk_id = 2;
@@ -115,6 +133,15 @@ message UnlinkRequest {
 
 message UnlinkResponse {
   common.Status status = 1;
+}
+
+message UnlinkAllRequest {
+  string id = 1;
+}
+
+message UnlinkAllResponse {
+  common.Status status = 1;
+  int32 num_chunks_unlinked = 2;  // number of chunks that were unlinked
 }
 
 

--- a/python/cornserve/sidecar/constants.py
+++ b/python/cornserve/sidecar/constants.py
@@ -11,6 +11,11 @@ CHUNK_OFFSET = 1000
 GRPC_BASE_PORT = 10000
 UCX_BASE_PORT = 12000
 
+# Retry configuration for gRPC calls
+GRPC_RETRY_MAX_ATTEMPTS = 3  # 3 total attempts (1 initial + 2 retries)
+GRPC_RETRY_INITIAL_BACKOFF_SECONDS = 0.05  # Initial backoff delay in seconds
+GRPC_RETRY_BACKOFF_MULTIPLIER = 2.0  # Exponential backoff multiplier
+
 
 def chunk_tag(id: str, rank: int, chunk_id: int, shard_rank: int) -> int:
     """Generate a tag for the chunk.

--- a/python/cornserve/task_executors/geri/engine/client.py
+++ b/python/cornserve/task_executors/geri/engine/client.py
@@ -257,7 +257,8 @@ class EngineClient:
             else:
                 logger.info("Error detected for request %s", request_id)
                 break
-
+        # Attempt to free all sidecar buffers associated with this request
+        await self.sidecar.mark_done_all(request.embedding_data_id)
         # Cleanup
         self.pending_streams.pop(request_id)
 

--- a/tasklib/cornserve_tasklib/task_executors/descriptor/omni.py
+++ b/tasklib/cornserve_tasklib/task_executors/descriptor/omni.py
@@ -27,7 +27,6 @@ async def parse_stream_to_audio_chunks(
     response: aiohttp.ClientResponse,
 ) -> AsyncGenerator[str]:
     """Parse the streaming response into audio chunks."""
-    assert not response.closed, "Response must not be closed when parsing."
     try:
         buffer = b""
         # Read in larger chunks to avoid "Chunk too big" error with large base64-encoded audio
@@ -57,7 +56,8 @@ async def parse_stream_to_audio_chunks(
                 chunk = OpenAIChatCompletionChunk.model_validate_json(line)
                 yield chunk.model_dump_json()
     finally:
-        response.close()
+        if not response.closed:
+            response.close()
 
 
 class OmniTalkerVocoderDescriptor(


### PR DESCRIPTION
NOTE: only tested exmaples/mllm.py so far. Need more tests.